### PR TITLE
Migrate from Gatsby to Astro

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,34 +1,65 @@
-name: Build & Deploy
+name: Generate & Upload CV PDFs
 
 on:
   push:
     branches:
       - main
-  pull_request:
+    paths:
+      - 'src/pages/cv.astro'
+      - 'src/pages/cv/**'
+      - 'src/data/sharedcv.*'
+      - 'src/layouts/Layout.astro'
+      - 'src/components/SubNavbar.astro'
+      - 'src/components/Obfuscate.astro'
+      - 'src/styles/**'
+      - 'scripts/build-pdf.mjs'
+  workflow_dispatch:
 
 permissions:
   contents: read
-  deployments: write
 
 jobs:
-  build:
+  generate-pdfs:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22
+
       - name: Install dependencies
         run: npm ci
-      - name: Build
+
+      - name: Build site
         run: npm run build
-      - name: Deploy to Cloudflare
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+      - name: Install Chrome for Puppeteer
+        run: npx puppeteer browsers install chrome-headless-shell
+
+      - name: Generate PDFs
+        run: npm run build:pdf
+
+      - name: Upload CV PDF to R2
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy
+          command: r2 object put matthewmincher-assets/matthewmincher-cv.pdf --file dist/exports/matthewmincher-cv.pdf --content-type application/pdf
+
+      - name: Upload Backend CV PDF to R2
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: r2 object put matthewmincher-assets/matthewmincher-cv-backend.pdf --file dist/exports/matthewmincher-cv-backend.pdf --content-type application/pdf
+
+      - name: Upload Frontend CV PDF to R2
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: r2 object put matthewmincher-assets/matthewmincher-cv-frontend.pdf --file dist/exports/matthewmincher-cv-frontend.pdf --content-type application/pdf

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build && npx puppeteer browsers install chrome-headless-shell && node scripts/build-pdf.mjs",
+    "build": "astro build",
     "build:pdf": "node scripts/build-pdf.mjs",
     "preview": "astro preview"
   },

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -12,7 +12,7 @@ import pdfIcon from "../images/icon_pdf.svg";
   <div class="w-full max-w-screen-xl mx-auto print:px-4 print:text-[80%] px-2.5">
     <div class="float-end mr-7 text-sm group print:hidden">
       <a
-        href="/exports/matthewmincher-cv.pdf"
+        href="https://assets.matthewmincher.dev/matthewmincher-cv.pdf"
         target="_blank"
         rel="noreferrer"
         class="px-1 py-3"

--- a/src/pages/cv/backend.astro
+++ b/src/pages/cv/backend.astro
@@ -12,7 +12,7 @@ import pdfIcon from "../../images/icon_pdf.svg";
   <div class="w-full max-w-screen-xl mx-auto print:px-4 print:text-[80%] px-2.5">
     <div class="float-end mr-7 text-sm group print:hidden">
       <a
-        href="/exports/matthewmincher-cv-backend.pdf"
+        href="https://assets.matthewmincher.dev/matthewmincher-cv-backend.pdf"
         target="_blank"
         rel="noreferrer"
         class="px-1 py-3"

--- a/src/pages/cv/frontend.astro
+++ b/src/pages/cv/frontend.astro
@@ -12,7 +12,7 @@ import pdfIcon from "../../images/icon_pdf.svg";
   <div class="w-full max-w-screen-xl mx-auto print:px-4 print:text-[80%] px-2.5">
     <div class="float-end mr-7 text-sm group print:hidden">
       <a
-        href="/exports/matthewmincher-cv-frontend.pdf"
+        href="https://assets.matthewmincher.dev/matthewmincher-cv-frontend.pdf"
         target="_blank"
         rel="noreferrer"
         class="px-1 py-3"


### PR DESCRIPTION
## Summary

- Replace Gatsby with Astro for static site generation
- Port all pages (homepage, CV variants, contact form, 404) to Astro components
- Contact form ported as a React island via `@astrojs/react`
- CSS email/phone obfuscation replaces JS-based approach
- PDF CV generation moved to GitHub Actions with Cloudflare R2 storage (`assets.matthewmincher.dev`)
- Deploy via Cloudflare Workers static assets (replaces AWS S3 + CloudFront)
- Fix Tailwind v3→v4 spacing drift (line-height, heading sizes)

## Infrastructure changes

- `npm run build` simplified to just `astro build` (Cloudflare auto-build compatible)
- New GitHub Actions workflow generates PDFs on CV file changes and uploads to R2
- Removed Gatsby config, SCSS, old React page components, and unused assets
- `package-lock.json` reduced significantly (~24k lines removed)

## Test plan

- [x] Homepage matches prod visually (Chrome DevTools comparison)
- [x] CV page matches prod visually (spacing drift fixed)
- [x] Contact page matches prod visually
- [x] Build succeeds without Puppeteer
- [ ] Cloudflare auto-build deploys successfully
- [ ] PDF generation workflow runs and uploads to R2
- [ ] PDF download links work from live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)