### PR TITLE
Fix PDF generation styling

### DIFF
--- a/scripts/build-pdf.mjs
+++ b/scripts/build-pdf.mjs
@@ -58,15 +58,22 @@ function startServer() {
   });
 }
 
+async function launchBrowser() {
+  const args = ["--no-sandbox", "--disable-setuid-sandbox"];
+  try {
+    return await puppeteer.launch({ headless: "shell", args });
+  } catch {
+    console.log("Bundled Chrome failed, falling back to system Chrome...");
+    return await puppeteer.launch({ headless: true, channel: "chrome", args });
+  }
+}
+
 async function buildPdfs() {
   mkdirSync(exportsDir, { recursive: true });
 
   let browser;
   try {
-    browser = await puppeteer.launch({
-      headless: "shell",
-      args: ["--no-sandbox", "--disable-setuid-sandbox"],
-    });
+    browser = await launchBrowser();
   } catch (err) {
     console.warn(`Skipping PDF generation: ${err.message}`);
     return;

--- a/scripts/build-pdf.mjs
+++ b/scripts/build-pdf.mjs
@@ -27,10 +27,7 @@ const mimeTypes = {
 };
 
 const printStyles = `
-  .constrainedContent { padding: 0 40px; }
   .afterPageBreak { padding-top: 40px; }
-  .telephone { display: block; }
-  .download { display: none; }
 `;
 
 function startServer() {
@@ -88,6 +85,7 @@ async function buildPdfs() {
 
     const tab = await browser.newPage();
     await tab.goto(url, { waitUntil: "networkidle0" });
+    await tab.emulateMediaType("print");
     await tab.addStyleTag({ content: printStyles });
     await tab.pdf({
       path: outputPath,


### PR DESCRIPTION
## Summary

- Serve `dist/` via local HTTP server instead of `file://` URLs so absolute asset paths (`/_astro/style.css`) resolve correctly
- Restore system Chrome fallback (`channel: "chrome"`) when bundled `chrome-headless-shell` fails (e.g. macOS Gatekeeper)
- Add `emulateMediaType('print')` so Tailwind `print:` variants apply during PDF rendering
- Remove dead Gatsby-era class overrides (`.constrainedContent`, `.telephone`, `.download`)

## Test plan

- [x] PDFs generate successfully locally with system Chrome fallback
- [x] Generated PDFs include CSS styling (~300KB each)
- [x] Print styles apply (nav hidden, phone number visible)
- [ ] GitHub Actions workflow generates and uploads PDFs to R2

🤖 Generated with [Claude Code](https://claude.com/claude-code)