### PR TITLE
Add CDN cache purge after R2 PDF upload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,8 +65,11 @@ jobs:
           command: r2 object put matthewmincher-assets/matthewmincher-cv-frontend.pdf --file dist/exports/matthewmincher-cv-frontend.pdf --content-type application/pdf
 
       - name: Purge CDN cache for PDFs
-        run: |
-          curl -s -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE }}/purge_cache" \
-            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            --data '{"files":["https://assets.matthewmincher.dev/matthewmincher-cv.pdf","https://assets.matthewmincher.dev/matthewmincher-cv-backend.pdf","https://assets.matthewmincher.dev/matthewmincher-cv-frontend.pdf"]}'
+        uses: nathanvaughn/actions-cloudflare-purge@v3.1.0
+        with:
+          cf_zone: ${{ secrets.CLOUDFLARE_ZONE }}
+          cf_auth: ${{ secrets.CLOUDFLARE_TOKEN }}
+          urls: |
+            https://assets.matthewmincher.dev/matthewmincher-cv.pdf
+            https://assets.matthewmincher.dev/matthewmincher-cv-backend.pdf
+            https://assets.matthewmincher.dev/matthewmincher-cv-frontend.pdf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Purge CDN cache for PDFs
         run: |
-          curl -s -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/purge_cache" \
+          curl -s -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE }}/purge_cache" \
             -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_TOKEN }}" \
             -H "Content-Type: application/json" \
             --data '{"files":["https://assets.matthewmincher.dev/matthewmincher-cv.pdf","https://assets.matthewmincher.dev/matthewmincher-cv-backend.pdf","https://assets.matthewmincher.dev/matthewmincher-cv-frontend.pdf"]}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,3 +63,10 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: r2 object put matthewmincher-assets/matthewmincher-cv-frontend.pdf --file dist/exports/matthewmincher-cv-frontend.pdf --content-type application/pdf
+
+      - name: Purge CDN cache for PDFs
+        run: |
+          curl -s -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/purge_cache" \
+            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            --data '{"files":["https://assets.matthewmincher.dev/matthewmincher-cv.pdf","https://assets.matthewmincher.dev/matthewmincher-cv-backend.pdf","https://assets.matthewmincher.dev/matthewmincher-cv-frontend.pdf"]}'


### PR DESCRIPTION
## Summary

- Purge Cloudflare CDN edge cache for the three PDF URLs after uploading to R2
- Uses `nathanvaughn/actions-cloudflare-purge@v3.1.0` (same action as the old Gatsby workflow)
- Ensures updated PDFs are served immediately rather than stale cached versions

## Test plan

- [ ] Trigger workflow manually, verify cache purge step succeeds
- [ ] Confirm updated PDF is served at `assets.matthewmincher.dev` without manual purge

🤖 Generated with [Claude Code](https://claude.com/claude-code)