### PR TITLE
Fix PDF spacing to match production output

### DIFF
--- a/scripts/build-pdf.mjs
+++ b/scripts/build-pdf.mjs
@@ -27,6 +27,7 @@ const mimeTypes = {
 };
 
 const printStyles = `
+  html { font-size: 80%; }
   .afterPageBreak { padding-top: 40px; }
 `;
 
@@ -91,7 +92,7 @@ async function buildPdfs() {
       path: outputPath,
       format: "A4",
       printBackground: true,
-      margin: { top: "20px", bottom: "20px", left: "20px", right: "20px" },
+      margin: { top: 0, bottom: 0, left: 0, right: 0 },
     });
     await tab.close();
 

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -9,7 +9,7 @@ import pdfIcon from "../images/icon_pdf.svg";
 
 <Layout pageTitle="CV">
   <SubNavbar items={focusLinks} />
-  <div class="w-full max-w-screen-xl mx-auto print:px-4 print:text-[80%] px-2.5">
+  <div class="w-full max-w-screen-xl mx-auto print:px-4 px-2.5">
     <div class="float-end mr-7 text-sm group print:hidden">
       <a
         href="https://assets.matthewmincher.dev/matthewmincher-cv.pdf"
@@ -26,7 +26,7 @@ import pdfIcon from "../images/icon_pdf.svg";
       </a>
     </div>
 
-    <h1 class="text-[2rem] mt-[0.67em] mb-0">Matthew Mincher</h1>
+    <h1 class="text-[2em] mt-[0.67em] mb-0">Matthew Mincher</h1>
     <div class="mt-1">
       www.matthewmincher.dev
     </div>

--- a/src/pages/cv/backend.astro
+++ b/src/pages/cv/backend.astro
@@ -9,7 +9,7 @@ import pdfIcon from "../../images/icon_pdf.svg";
 
 <Layout pageTitle="CV - Backend">
   <SubNavbar items={focusLinks} />
-  <div class="w-full max-w-screen-xl mx-auto print:px-4 print:text-[80%] px-2.5">
+  <div class="w-full max-w-screen-xl mx-auto print:px-4 px-2.5">
     <div class="float-end mr-7 text-sm group print:hidden">
       <a
         href="https://assets.matthewmincher.dev/matthewmincher-cv-backend.pdf"
@@ -26,7 +26,7 @@ import pdfIcon from "../../images/icon_pdf.svg";
       </a>
     </div>
 
-    <h1 class="text-[2rem] mt-[0.67em] mb-0">Matthew Mincher</h1>
+    <h1 class="text-[2em] mt-[0.67em] mb-0">Matthew Mincher</h1>
     <div class="mt-1">
       www.matthewmincher.dev
     </div>

--- a/src/pages/cv/frontend.astro
+++ b/src/pages/cv/frontend.astro
@@ -9,7 +9,7 @@ import pdfIcon from "../../images/icon_pdf.svg";
 
 <Layout pageTitle="CV - Frontend">
   <SubNavbar items={focusLinks} />
-  <div class="w-full max-w-screen-xl mx-auto print:px-4 print:text-[80%] px-2.5">
+  <div class="w-full max-w-screen-xl mx-auto print:px-4 px-2.5">
     <div class="float-end mr-7 text-sm group print:hidden">
       <a
         href="https://assets.matthewmincher.dev/matthewmincher-cv-frontend.pdf"
@@ -26,7 +26,7 @@ import pdfIcon from "../../images/icon_pdf.svg";
       </a>
     </div>
 
-    <h1 class="text-[2rem] mt-[0.67em] mb-0">Matthew Mincher</h1>
+    <h1 class="text-[2em] mt-[0.67em] mb-0">Matthew Mincher</h1>
     <div class="mt-1">
       www.matthewmincher.dev
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,6 +4,7 @@
   html {
     line-height: normal;
   }
+
 }
 
 @media screen and (min-width: 1024px) {


### PR DESCRIPTION
## Summary
- Move font-size 80% scaling from CV container class (`print:text-[80%]`) into `build-pdf.mjs` printStyles on the root element, so all `rem`-based margins and padding scale proportionally during PDF generation
- Change h1 from `text-[2rem]` to `text-[2em]` so heading size scales with the font-size reduction
- Set Puppeteer page margins to 0 to match the edge-to-edge layout of the original PDFs

## Test plan
- [ ] Run `npm run build && npm run build:pdf` locally
- [ ] Compare generated PDFs against https://www.matthewmincher.dev/exports/matthewmincher-cv.pdf
- [ ] Verify page margins, content density, and page break positions match
- [ ] Verify screen layout of CV pages is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)