### PR TITLE
Add blog and elevate site design

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@astrojs/react": "^4.0.0",
         "@astrojs/sitemap": "^3.7.2",
         "@tailwindcss/postcss": "^4.0.0",
+        "@tailwindcss/typography": "^0.5.19",
         "astro": "^6.2.0",
         "astro-icon": "^1.1.0",
         "react": "^19.0.0",
@@ -2280,6 +2281,18 @@
         "tailwindcss": "4.2.4"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -3307,6 +3320,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/csso": {
@@ -6057,6 +6082,19 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/prismjs": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
@@ -7354,6 +7392,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/validator": {
       "version": "13.15.35",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@astrojs/react": "^4.0.0",
     "@astrojs/sitemap": "^3.7.2",
     "@tailwindcss/postcss": "^4.0.0",
+    "@tailwindcss/typography": "^0.5.19",
     "astro": "^6.2.0",
     "astro-icon": "^1.1.0",
     "react": "^19.0.0",

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -79,7 +79,7 @@ export default function ContactForm() {
 
   return (
     <form
-      className="bg-stone-100 rounded-xl mt-10 mb-10 p-6"
+      className="bg-stone-100 rounded-2xl mt-10 mb-10 p-8 border border-stone-200"
       method="post"
       onSubmit={handleSubmit}
     >
@@ -91,7 +91,7 @@ export default function ContactForm() {
             </label>
           </div>
           <input
-            className="w-full h-10 text-xl box-border border border-stone-200 p-2 outline-emerald-500 mb-5"
+            className="w-full h-10 text-xl box-border border border-stone-200 rounded-lg p-2 outline-emerald-500 mb-5 transition-colors focus:border-emerald-500"
             id="name"
             type="text"
             name="name"
@@ -112,7 +112,7 @@ export default function ContactForm() {
             )}
           </div>
           <input
-            className="w-full h-10 text-xl box-border border border-stone-200 p-2 outline-emerald-500 mb-5"
+            className="w-full h-10 text-xl box-border border border-stone-200 rounded-lg p-2 outline-emerald-500 mb-5 transition-colors focus:border-emerald-500"
             id="email"
             type="email"
             name="email"
@@ -135,7 +135,7 @@ export default function ContactForm() {
         )}
       </div>
       <textarea
-        className="w-full text-xl box-border border border-stone-200 p-2 outline-emerald-500 mb-5"
+        className="w-full text-xl box-border border border-stone-200 rounded-lg p-2 outline-emerald-500 mb-5 transition-colors focus:border-emerald-500"
         id="message"
         name="message"
         rows={5}

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,7 +2,7 @@
 const year = new Date().getFullYear();
 ---
 
-<footer class="bg-stone-100 border-t-4 border-stone-300 min-h-12 py-3 text-xs text-stone-600 box-border print:hidden px-2.5">
+<footer class="bg-stone-100 border-t border-stone-200 py-6 text-sm text-stone-500 box-border print:hidden px-5">
   <div class="w-full mx-auto max-w-screen-xl">
     &copy; Matthew Mincher {year}
   </div>

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -15,8 +15,8 @@ const contactClass =
 const contactActiveClass = "text-stone-100 bg-emerald-900";
 ---
 
-<nav class="bg-stone-100 print:hidden">
-  <div class="w-full mx-auto h-16 px-2.5 flex flex-grow flex-shrink-0 max-w-screen-xl">
+<nav class="bg-stone-100 border-b border-stone-200 print:hidden">
+  <div class="w-full mx-auto h-16 px-5 flex flex-grow flex-shrink-0 max-w-screen-xl">
     <ul class="m-0 p-0 list-none flex gap-x-6">
       <li class="flex flex-grow-0 flex-shrink flex-row">
         <a

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -3,6 +3,7 @@ const pathname = Astro.url.pathname;
 
 const isHome = pathname === "/";
 const isCv = pathname.startsWith("/cv");
+const isBlog = pathname.startsWith("/blog");
 const isContact = pathname.startsWith("/contact");
 
 const linkClass =
@@ -31,6 +32,14 @@ const contactActiveClass = "text-stone-100 bg-emerald-900";
           class:list={[linkClass, isCv && activeClass]}
         >
           CV
+        </a>
+      </li>
+      <li class="flex flex-grow-0 flex-shrink flex-row">
+        <a
+          href="/blog/"
+          class:list={[linkClass, isBlog && activeClass]}
+        >
+          Blog
         </a>
       </li>
     </ul>

--- a/src/components/SubNavbar.astro
+++ b/src/components/SubNavbar.astro
@@ -11,8 +11,8 @@ const linkClass =
 const activeClass = "text-emerald-500 border-b-emerald-500";
 ---
 
-<nav class="bg-stone-100 print:hidden">
-  <div class="w-full mx-auto px-2.5 flex flex-grow flex-shrink-0 max-w-screen-xl">
+<nav class="bg-stone-100 border-b border-stone-200 print:hidden">
+  <div class="w-full mx-auto px-5 flex flex-grow flex-shrink-0 max-w-screen-xl">
     <ul class="m-0 p-0 list-none flex gap-x-6">
       {items.map((item) => (
         <li>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,14 @@
+import { defineCollection, z } from "astro:content";
+import { glob } from "astro/loaders";
+
+const blog = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/blog" }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    date: z.date(),
+    tags: z.array(z.string()).optional(),
+  }),
+});
+
+export const collections = { blog };

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -19,6 +19,9 @@ const { pageTitle } = Astro.props;
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="theme-color" content="#33ca7f" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=Sora:wght@400;600;700;800&display=swap" rel="stylesheet" />
   </head>
   <body>
     <main class="border-t-4 border-emerald-900 box-border min-h-screen flex flex-col">

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -15,22 +15,22 @@ const { Content } = await render(post);
 ---
 
 <Layout pageTitle={post.data.title}>
-  <div class="w-full mx-auto max-w-screen-xl px-2.5 py-10">
+  <div class="w-full mx-auto max-w-screen-xl px-5 py-10">
     <a href="/blog/" class="text-emerald-900 hover:text-emerald-500 transition-colors duration-200 text-sm font-bold">
       &larr; Back to blog
     </a>
 
-    <article class="mt-6">
-      <h1 class="text-emerald-500 text-4xl font-bold mb-2">{post.data.title}</h1>
-      <time class="text-sm text-gray-500" datetime={post.data.date.toISOString()}>
+    <article class="mt-8 max-w-2xl">
+      <time class="text-xs text-gray-400 font-medium tracking-wider uppercase" datetime={post.data.date.toISOString()}>
         {post.data.date.toLocaleDateString("en-GB", {
           year: "numeric",
           month: "long",
           day: "numeric",
         })}
       </time>
+      <h1 class="font-display text-emerald-500 text-4xl md:text-5xl font-bold mt-2 mb-8 leading-tight">{post.data.title}</h1>
 
-      <div class="prose prose-emerald mt-8 max-w-none">
+      <div class="prose prose-emerald prose-lg max-w-none prose-headings:font-display prose-a:text-emerald-600 prose-a:decoration-emerald-300 hover:prose-a:decoration-emerald-500">
         <Content />
       </div>
     </article>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,0 +1,38 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import { getCollection, render } from "astro:content";
+
+export async function getStaticPaths() {
+  const posts = await getCollection("blog");
+  return posts.map((post) => ({
+    params: { slug: post.id },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+---
+
+<Layout pageTitle={post.data.title}>
+  <div class="w-full mx-auto max-w-screen-xl px-2.5 py-10">
+    <a href="/blog/" class="text-emerald-900 hover:text-emerald-500 transition-colors duration-200 text-sm font-bold">
+      &larr; Back to blog
+    </a>
+
+    <article class="mt-6">
+      <h1 class="text-emerald-500 text-4xl font-bold mb-2">{post.data.title}</h1>
+      <time class="text-sm text-gray-500" datetime={post.data.date.toISOString()}>
+        {post.data.date.toLocaleDateString("en-GB", {
+          year: "numeric",
+          month: "long",
+          day: "numeric",
+        })}
+      </time>
+
+      <div class="prose prose-emerald mt-8 max-w-none">
+        <Content />
+      </div>
+    </article>
+  </div>
+</Layout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -8,27 +8,27 @@ const posts = (await getCollection("blog")).sort(
 ---
 
 <Layout pageTitle="Blog">
-  <div class="w-full mx-auto max-w-screen-xl px-2.5 py-10">
-    <h1 class="text-emerald-500 text-4xl font-bold mb-8">Blog</h1>
+  <div class="w-full mx-auto max-w-screen-xl px-5 py-10">
+    <h1 class="font-display text-emerald-500 text-4xl font-bold mb-10">Blog</h1>
 
     {posts.length === 0 ? (
       <p class="text-gray-500">No posts yet. Check back soon.</p>
     ) : (
-      <ul class="space-y-6">
+      <ul class="divide-y divide-stone-200">
         {posts.map((post) => (
-          <li>
+          <li class="py-8 first:pt-0">
             <a href={`/blog/${post.id}/`} class="group block">
-              <h2 class="text-xl font-bold text-emerald-900 group-hover:text-emerald-500 transition-colors duration-200">
-                {post.data.title}
-              </h2>
-              <time class="text-sm text-gray-500" datetime={post.data.date.toISOString()}>
+              <time class="text-xs text-gray-400 font-medium tracking-wider uppercase" datetime={post.data.date.toISOString()}>
                 {post.data.date.toLocaleDateString("en-GB", {
                   year: "numeric",
                   month: "long",
                   day: "numeric",
                 })}
               </time>
-              <p class="text-gray-600 mt-1">{post.data.description}</p>
+              <h2 class="font-display text-2xl font-bold text-emerald-900 group-hover:text-emerald-500 transition-colors duration-200 mt-1">
+                {post.data.title}
+              </h2>
+              <p class="text-gray-600 mt-2 leading-relaxed">{post.data.description}</p>
             </a>
           </li>
         ))}

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,38 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import { getCollection } from "astro:content";
+
+const posts = (await getCollection("blog")).sort(
+  (a, b) => b.data.date.getTime() - a.data.date.getTime(),
+);
+---
+
+<Layout pageTitle="Blog">
+  <div class="w-full mx-auto max-w-screen-xl px-2.5 py-10">
+    <h1 class="text-emerald-500 text-4xl font-bold mb-8">Blog</h1>
+
+    {posts.length === 0 ? (
+      <p class="text-gray-500">No posts yet. Check back soon.</p>
+    ) : (
+      <ul class="space-y-6">
+        {posts.map((post) => (
+          <li>
+            <a href={`/blog/${post.id}/`} class="group block">
+              <h2 class="text-xl font-bold text-emerald-900 group-hover:text-emerald-500 transition-colors duration-200">
+                {post.data.title}
+              </h2>
+              <time class="text-sm text-gray-500" datetime={post.data.date.toISOString()}>
+                {post.data.date.toLocaleDateString("en-GB", {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                })}
+              </time>
+              <p class="text-gray-600 mt-1">{post.data.description}</p>
+            </a>
+          </li>
+        ))}
+      </ul>
+    )}
+  </div>
+</Layout>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -4,8 +4,8 @@ import ContactForm from "../components/ContactForm";
 ---
 
 <Layout pageTitle="Contact Me">
-  <div class="w-full mx-auto max-w-screen-xl px-2.5">
-    <h1 class="mt-16 text-center text-emerald-500 text-3xl md:text-4xl">Leave me a message and I'll get back to you</h1>
+  <div class="w-full mx-auto max-w-screen-xl px-5">
+    <h1 class="font-display mt-16 text-center text-emerald-500 text-3xl md:text-4xl">Leave me a message and I'll get back to you</h1>
 
     <ContactForm client:load />
   </div>

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -9,7 +9,7 @@ import pdfIcon from "../images/icon_pdf.svg";
 
 <Layout pageTitle="CV">
   <SubNavbar items={focusLinks} />
-  <div class="w-full max-w-screen-xl mx-auto print:px-4 px-2.5">
+  <div class="w-full max-w-screen-xl mx-auto print:px-4 px-5">
     <div class="float-end mr-7 text-sm group print:hidden">
       <a
         href="https://assets.matthewmincher.dev/matthewmincher-cv.pdf"
@@ -26,7 +26,7 @@ import pdfIcon from "../images/icon_pdf.svg";
       </a>
     </div>
 
-    <h1 class="text-[2em] mt-[0.67em] mb-0">Matthew Mincher</h1>
+    <h1 class="font-display print:font-sans text-[2em] mt-[0.67em] mb-0">Matthew Mincher</h1>
     <div class="mt-1">
       www.matthewmincher.dev
     </div>
@@ -41,10 +41,10 @@ import pdfIcon from "../images/icon_pdf.svg";
     </div>
     <div class="mt-1">Chester, UK</div>
 
-    <h2 class="text-xl mt-4 mb-1 font-bold">Personal Statement</h2>
+    <h2 class="font-display print:font-sans text-2xl mt-10 print:mt-4 mb-2 font-bold border-t border-stone-200 print:border-0 pt-8 print:pt-0">Personal Statement</h2>
     <Fragment set:html={personalStatement} />
 
-    <h2 class="text-xl mt-4 font-bold">Skills</h2>
+    <h2 class="font-display print:font-sans text-2xl mt-10 print:mt-4 font-bold border-t border-stone-200 print:border-0 pt-8 print:pt-0">Skills</h2>
     <div class="flex flex-wrap">
       <ul class="min-w-[50%] p-0 m-0 list-disc">
         <li class="list-none text-lg mb-1">Platform</li>
@@ -79,7 +79,7 @@ import pdfIcon from "../images/icon_pdf.svg";
       </ul>
     </div>
 
-    <h2 class="text-xl mt-4 font-bold mb-1">Experience</h2>
+    <h2 class="font-display print:font-sans text-2xl mt-10 print:mt-4 font-bold mb-2 border-t border-stone-200 print:border-0 pt-8 print:pt-0">Experience</h2>
 
     <h3 class="text-emerald-900 text-lg font-bold">Forge Holiday Group, 2022 - Present</h3>
     <div class="italic">Lead Developer</div>
@@ -109,7 +109,7 @@ import pdfIcon from "../images/icon_pdf.svg";
           <div>
             <ul class="list-none">
               {['PHP', 'MySQL', 'REST', 'HTML/CSS', 'Javascript / jQuery', 'Apache Cordova', 'iOS (Objective-C, then Swift)', 'Android (Java)', 'Linux', 'ReactPHP', 'ZeroMQ', 'Redis', 'Memcached', 'Solr', 'In App Billing', 'Push Notifications', 'Game Design'].map((s) => (
-                <li class="border-b-2 border-dotted border-gray-300 mr-4 mb-1 inline-block">{s}</li>
+                <li class="text-sm border border-stone-300 rounded-full px-3 py-0.5 mr-2 mb-2 inline-block text-stone-600">{s}</li>
               ))}
             </ul>
           </div>
@@ -138,7 +138,7 @@ import pdfIcon from "../images/icon_pdf.svg";
         <div>
           <ul class="list-none">
             {['iOS (Swift)', 'Android (Java)', 'API Integration', 'Security / Robustness', 'Encryption', 'Authentication', 'Agile'].map((s) => (
-              <li class="border-b-2 border-dotted border-gray-300 mr-4 mb-1 inline-block">{s}</li>
+              <li class="text-sm border border-stone-300 rounded-full px-3 py-0.5 mr-2 mb-2 inline-block text-stone-600">{s}</li>
             ))}
           </ul>
         </div>
@@ -156,7 +156,7 @@ import pdfIcon from "../images/icon_pdf.svg";
         <div>
           <ul class="list-none">
             {['PHP', 'REST API', 'MySQL', 'iOS (Swift)', 'Android (Java)', 'Javascript', 'Linux', 'Docker', 'RabbitMQ', 'API Integration', 'In App Billing', 'Push Notifications', 'Game Design'].map((s) => (
-              <li class="border-b-2 border-dotted border-gray-300 mr-4 mb-1 inline-block">{s}</li>
+              <li class="text-sm border border-stone-300 rounded-full px-3 py-0.5 mr-2 mb-2 inline-block text-stone-600">{s}</li>
             ))}
           </ul>
         </div>
@@ -171,7 +171,7 @@ import pdfIcon from "../images/icon_pdf.svg";
         <div>
           <ul class="list-none">
             {['PHP', 'MySQL', 'HTML/CSS', 'Javascript', 'Three.js', 'Linux', 'Apache Cordova', 'ReactPHP', 'RabbitMQ', 'Game Design'].map((s) => (
-              <li class="border-b-2 border-dotted border-gray-300 mr-4 mb-1 inline-block">{s}</li>
+              <li class="text-sm border border-stone-300 rounded-full px-3 py-0.5 mr-2 mb-2 inline-block text-stone-600">{s}</li>
             ))}
           </ul>
         </div>
@@ -187,7 +187,7 @@ import pdfIcon from "../images/icon_pdf.svg";
     <div>
       <ul class="list-none">
         {['PHP', 'MySQL', 'jQuery', 'HTML/CSS', 'Linux', 'Solr', 'A/B Testing'].map((s) => (
-          <li class="border-b-2 border-dotted border-gray-300 mr-4 mb-1 inline-block">{s}</li>
+          <li class="text-sm border border-stone-300 rounded-full px-3 py-0.5 mr-2 mb-2 inline-block text-stone-600">{s}</li>
         ))}
       </ul>
     </div>
@@ -201,12 +201,12 @@ import pdfIcon from "../images/icon_pdf.svg";
     <div>
       <ul class="list-none">
         {['PHP', 'MySQL', 'jQuery', 'HTML/CSS', 'Game Design'].map((s) => (
-          <li class="border-b-2 border-dotted border-gray-300 mr-4 mb-1 inline-block">{s}</li>
+          <li class="text-sm border border-stone-300 rounded-full px-3 py-0.5 mr-2 mb-2 inline-block text-stone-600">{s}</li>
         ))}
       </ul>
     </div>
 
-    <h2 class="text-xl mt-4 font-bold mb-1">Education</h2>
+    <h2 class="font-display print:font-sans text-2xl mt-10 print:mt-4 font-bold mb-2 border-t border-stone-200 print:border-0 pt-8 print:pt-0">Education</h2>
 
     <h3 class="text-emerald-900 text-lg font-bold">University of Chester, 2007 - 2010</h3>
     <div>BSc Computer Science - first-class honors</div>

--- a/src/pages/cv/backend.astro
+++ b/src/pages/cv/backend.astro
@@ -9,7 +9,7 @@ import pdfIcon from "../../images/icon_pdf.svg";
 
 <Layout pageTitle="CV - Backend">
   <SubNavbar items={focusLinks} />
-  <div class="w-full max-w-screen-xl mx-auto print:px-4 px-2.5">
+  <div class="w-full max-w-screen-xl mx-auto print:px-4 px-5">
     <div class="float-end mr-7 text-sm group print:hidden">
       <a
         href="https://assets.matthewmincher.dev/matthewmincher-cv-backend.pdf"

--- a/src/pages/cv/frontend.astro
+++ b/src/pages/cv/frontend.astro
@@ -9,7 +9,7 @@ import pdfIcon from "../../images/icon_pdf.svg";
 
 <Layout pageTitle="CV - Frontend">
   <SubNavbar items={focusLinks} />
-  <div class="w-full max-w-screen-xl mx-auto print:px-4 px-2.5">
+  <div class="w-full max-w-screen-xl mx-auto print:px-4 px-5">
     <div class="float-end mr-7 text-sm group print:hidden">
       <a
         href="https://assets.matthewmincher.dev/matthewmincher-cv-frontend.pdf"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,16 +8,16 @@ import mapImage from "../images/map.png";
 ---
 
 <Layout pageTitle="Home">
-  <div class="w-[120px] h-[120px] bg-gray-400 mt-10 mx-auto overflow-hidden rounded-3xl">
+  <div class="w-[120px] h-[120px] bg-gray-400 mt-16 mx-auto overflow-hidden rounded-3xl ring-4 ring-emerald-500/20 ring-offset-4 ring-offset-white">
     <Image src={meImage} width={120} height={120} quality={100} alt="Matthew Mincher" />
   </div>
-  <h1 class="text-emerald-500 text-center text-5xl my-1 font-bold">Matthew Mincher</h1>
-  <div class="text-center text-gray-600">Full Stack Developer.</div>
+  <h1 class="font-display text-emerald-500 text-center text-5xl md:text-6xl my-2 font-bold">Matthew Mincher</h1>
+  <div class="text-center text-gray-500 tracking-wide text-lg font-light">Full Stack Developer.</div>
 
-  <div class="bg-emerald-950 mt-20 mb-10 py-8 px-2.5">
+  <div class="bg-emerald-950 mt-24 mb-10 py-8 px-5">
     <div class="w-full mx-auto max-w-screen-xl">
       <div class="relative pt-[300px] md:pt-0">
-        <h2 class="text-emerald-500 opacity-80 text-4xl mb-8 font-bold">Around the web</h2>
+        <h2 class="font-display text-emerald-500 opacity-80 text-4xl mb-8 font-bold">Around the web</h2>
 
         <div class="absolute -top-14 right-1/2 translate-x-1/2 md:-right-14 md:translate-x-0 md:-bottom-14 bg-white rounded-xl overflow-hidden border-1 border-stone-100">
           <Image src={mapImage} width={488} height={310} quality={100} alt="Based in Chester, UK" />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@plugin "@tailwindcss/typography";
 
 @layer base {
   html {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,16 +1,33 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
+@theme {
+  --font-display: 'Sora', system-ui, sans-serif;
+  --font-body: 'Outfit', system-ui, sans-serif;
+}
+
 @layer base {
   html {
     line-height: normal;
+    font-family: var(--font-body);
+    letter-spacing: -0.01em;
   }
 
+  ::selection {
+    background-color: oklch(69.6% 0.17 162.48 / 0.25);
+  }
 }
 
 @media screen and (min-width: 1024px) {
   html {
     margin-right: calc(-100vw + 100%);
     overflow-x: hidden;
+  }
+}
+
+@media print {
+  html {
+    font-family: system-ui, sans-serif;
+    letter-spacing: normal;
   }
 }


### PR DESCRIPTION
## Summary
- Add Markdown blog using Astro content collections with typed frontmatter, listing page with empty state, and individual post pages with prose styling
- Elevate site design with Sora + Outfit fonts, CV section dividers and tag pills, editorial blog layout, and improved mobile padding

## Test plan
- [ ] Verify blog listing at `/blog/` shows empty state
- [ ] Add a test post to `src/content/blog/` and verify it renders at `/blog/[slug]/`
- [ ] Check homepage, CV, contact, and blog pages on mobile and desktop
- [ ] Verify CV prints correctly (print styles preserved)
- [ ] Confirm fonts load and display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)