### PR TITLE
Add Bookwyrm reading feed to homepage

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,6 +7,6 @@ export default defineConfig({
   site: "https://www.matthewmincher.dev",
   integrations: [react(), icon(), sitemap()],
   image: {
-    domains: ["pxscdn.com"],
+    domains: ["pxscdn.com", "bookwyrm-social.sfo3.digitaloceanspaces.com"],
   },
 });

--- a/src/data/bookwyrm.ts
+++ b/src/data/bookwyrm.ts
@@ -1,0 +1,92 @@
+interface BookwyrmBook {
+  title: string;
+  author: string;
+  coverUrl: string;
+  bookUrl: string;
+  status: "reading" | "finished";
+  rating?: number;
+}
+
+const BOOKWYRM_USER = "https://bookwyrm.social/user/matthewmincher";
+const ACCEPT_HEADER = { Accept: "application/activity+json" };
+
+async function fetchJson(url: string) {
+  const response = await fetch(url, { headers: ACCEPT_HEADER });
+  return response.json();
+}
+
+async function resolveAuthor(authorUrl: string): Promise<string> {
+  const data = await fetchJson(authorUrl);
+  return data.name ?? "Unknown";
+}
+
+async function fetchRatings(): Promise<Map<string, number>> {
+  const outbox = await fetchJson(`${BOOKWYRM_USER}/outbox?page=true`);
+  const ratings = new Map<string, number>();
+  for (const item of outbox.orderedItems ?? []) {
+    if (item.type === "Article" && item.rating && item.inReplyToBook) {
+      ratings.set(item.inReplyToBook, item.rating);
+    }
+  }
+  return ratings;
+}
+
+function mapBook(
+  item: any,
+  authorName: string,
+  status: "reading" | "finished",
+  rating?: number,
+): BookwyrmBook {
+  return {
+    title: item.title,
+    author: authorName,
+    coverUrl: item.cover?.url ?? "",
+    bookUrl: item.id,
+    status,
+    rating,
+  };
+}
+
+export async function getCurrentlyReading(
+  total = 4,
+): Promise<BookwyrmBook[]> {
+  const readingShelf = await fetchJson(
+    `${BOOKWYRM_USER}/books/reading?page=1`,
+  );
+  const readingItems = readingShelf.orderedItems ?? [];
+
+  const needed = Math.max(0, total - readingItems.length);
+  let finishedItems: any[] = [];
+  const [ratings] = await Promise.all([
+    needed > 0 ? fetchRatings() : Promise.resolve(new Map<string, number>()),
+    ...(needed > 0
+      ? [
+          fetchJson(`${BOOKWYRM_USER}/books/read?page=1`).then((shelf) => {
+            finishedItems = (shelf.orderedItems ?? []).slice(0, needed);
+          }),
+        ]
+      : []),
+  ]);
+
+  const allItems = [
+    ...readingItems.map((item: any) => ({ item, status: "reading" as const })),
+    ...finishedItems.map((item: any) => ({
+      item,
+      status: "finished" as const,
+    })),
+  ];
+
+  const books = await Promise.all(
+    allItems.map(async ({ item, status }) => {
+      const authorUrl = item.authors?.[0];
+      const authorName = authorUrl
+        ? await resolveAuthor(authorUrl)
+        : "Unknown";
+      const rating =
+        status === "finished" ? ratings.get(item.id) : undefined;
+      return mapBook(item, authorName, status, rating);
+    }),
+  );
+
+  return books;
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,10 +4,12 @@ import { Image } from "astro:assets";
 import { Icon } from "astro-icon/components";
 import contactData from "../data/aroundtheweb";
 import { getRecentPosts } from "../data/pixelfed";
+import { getCurrentlyReading } from "../data/bookwyrm";
 import meImage from "../images/me.jpeg";
 import mapImage from "../images/map.png";
 
 const recentPhotos = await getRecentPosts(4);
+const books = await getCurrentlyReading(4);
 ---
 
 <Layout pageTitle="Home">
@@ -92,6 +94,51 @@ const recentPhotos = await getRecentPosts(4);
               <p class="text-gray-400 text-sm mt-1">
                 {post.date.toLocaleDateString("en-GB", { day: "numeric", month: "long", year: "numeric" })}
               </p>
+            </div>
+          </a>
+        ))}
+      </div>
+    </div>
+  </div>
+
+  <div class="mt-16 mb-10 px-5">
+    <div class="w-full mx-auto max-w-screen-xl">
+      <h2 class="font-display text-emerald-500 opacity-80 text-4xl mb-8 font-bold">Currently reading</h2>
+      <div class="grid grid-cols-4 gap-3 md:gap-5">
+        {books.map((book) => (
+          <a
+            href={book.bookUrl}
+            target="_blank"
+            rel="noreferrer"
+            class="group block"
+          >
+            <div class="relative aspect-[2/3] overflow-hidden rounded-xl bg-gray-100">
+              {book.coverUrl && (
+                <Image
+                  src={book.coverUrl}
+                  alt={book.title}
+                  width={400}
+                  height={600}
+                  class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+                />
+              )}
+              <div class={`absolute top-2 right-2 md:top-3 md:right-3 text-white text-xs md:text-sm font-medium px-1.5 py-0.5 md:px-2.5 md:py-1 rounded-lg backdrop-blur-sm ${book.status === "reading" ? "bg-emerald-600/80" : "bg-black/60"}`}>
+                {book.status === "reading" ? "Reading" : "Finished"}
+              </div>
+            </div>
+            <div class="mt-2 md:mt-3">
+              <p class="text-gray-700 text-xs md:text-sm font-medium leading-snug line-clamp-2">{book.title}</p>
+              <p class="text-gray-400 text-xs md:text-sm mt-0.5 md:mt-1">{book.author}</p>
+              {book.rating && (
+                <div class="flex gap-0.5 mt-0.5 md:mt-1">
+                  {Array.from({ length: 5 }, (_, i) => (
+                    <Icon
+                      name="fa6-solid:star"
+                      class={`w-2.5 h-2.5 md:w-3.5 md:h-3.5 ${i < book.rating! ? "text-amber-400" : "text-gray-200"}`}
+                    />
+                  ))}
+                </div>
+              )}
             </div>
           </a>
         ))}


### PR DESCRIPTION
## Summary
- Add "Currently reading" section to the homepage below the Pixelfed photo feed
- Fetches currently reading books + recently finished books from the Bookwyrm ActivityPub API at build time, filling to 4 total
- Displays book covers with "Reading" (green) / "Finished" (dark) badges
- Shows star ratings for finished books that have reviews
- Cover images optimized through Astro's image pipeline
- Responsive: compact 4-column grid on mobile, full-sized on desktop

## Test plan
- [ ] Verify "Currently reading" section shows on homepage with book covers
- [ ] Check "Reading" and "Finished" badges appear correctly
- [ ] Confirm star ratings appear on finished books that have reviews
- [ ] Test responsive layout: compact on mobile, full-sized on desktop
- [ ] Verify book cards link to Bookwyrm in a new tab
- [ ] Confirm build succeeds with `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)