### PR TITLE
Make around the web section flush with footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,7 +2,7 @@
 const year = new Date().getFullYear();
 ---
 
-<footer class="bg-stone-100 border-t border-stone-200 py-6 text-sm text-stone-500 box-border print:hidden px-5">
+<footer class="bg-stone-100 border-t border-stone-200 lg:-mt-14 py-6 text-sm text-stone-500 box-border print:hidden px-5">
   <div class="w-full mx-auto max-w-screen-xl">
     &copy; Matthew Mincher {year}
   </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -26,7 +26,7 @@ const { pageTitle } = Astro.props;
   <body>
     <main class="border-t-4 border-emerald-900 box-border min-h-screen flex flex-col">
       <Navbar />
-      <div class="flex-grow overflow-x-hidden">
+      <div class="flex-grow overflow-hidden">
         <slot />
       </div>
       <Footer />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -26,7 +26,7 @@ const { pageTitle } = Astro.props;
   <body>
     <main class="border-t-4 border-emerald-900 box-border min-h-screen flex flex-col">
       <Navbar />
-      <div class="flex-grow overflow-hidden">
+      <div class="flex-grow overflow-x-hidden">
         <slot />
       </div>
       <Footer />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -107,7 +107,7 @@ const books = await getCurrentlyReading(4);
     </div>
   </div>
 
-  <div class="bg-emerald-950 mt-16 py-8 px-5">
+  <div class="bg-emerald-950 mt-16 py-8 px-5 relative z-10">
     <div class="w-full mx-auto max-w-screen-xl">
       <div class="relative md:pt-0">
         <h2 class="font-display text-emerald-500 opacity-80 text-4xl mb-8 font-bold">Around the web</h2>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -107,7 +107,7 @@ const books = await getCurrentlyReading(4);
     </div>
   </div>
 
-  <div class="bg-emerald-950 mt-16 py-8 px-5 relative z-10">
+  <div class="bg-emerald-950 mt-16 py-8 lg:pb-22 px-5">
     <div class="w-full mx-auto max-w-screen-xl">
       <div class="relative md:pt-0">
         <h2 class="font-display text-emerald-500 opacity-80 text-4xl mb-8 font-bold">Around the web</h2>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -107,7 +107,7 @@ const books = await getCurrentlyReading(4);
     </div>
   </div>
 
-  <div class="bg-emerald-950 mt-16 mb-14 py-8 px-5">
+  <div class="bg-emerald-950 mt-16 py-8 px-5">
     <div class="w-full mx-auto max-w-screen-xl">
       <div class="relative md:pt-0">
         <h2 class="font-display text-emerald-500 opacity-80 text-4xl mb-8 font-bold">Around the web</h2>


### PR DESCRIPTION
## Summary
- Remove bottom margin from the "Around the web" section so the green bar sits directly against the footer

## Test plan
- [ ] Verify the green bar touches the footer on desktop
- [ ] Verify the map still overlaps onto the footer at lg+ breakpoint
- [ ] Check mobile layout is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)