### PR TITLE
Align backend and frontend CV heading styles

### DIFF
--- a/src/pages/cv/backend.astro
+++ b/src/pages/cv/backend.astro
@@ -26,7 +26,7 @@ import pdfIcon from "../../images/icon_pdf.svg";
       </a>
     </div>
 
-    <h1 class="text-[2em] mt-[0.67em] mb-0">Matthew Mincher</h1>
+    <h1 class="font-display print:font-sans text-[2em] mt-[0.67em] mb-0">Matthew Mincher</h1>
     <div class="mt-1">
       www.matthewmincher.dev
     </div>
@@ -41,10 +41,10 @@ import pdfIcon from "../../images/icon_pdf.svg";
     </div>
     <div class="mt-1">Chester, UK</div>
 
-    <h2 class="text-xl mt-4 mb-1 font-bold">Personal Statement</h2>
+    <h2 class="font-display print:font-sans text-2xl mt-10 print:mt-4 mb-2 font-bold border-t border-stone-200 print:border-0 pt-8 print:pt-0">Personal Statement</h2>
     <Fragment set:html={personalStatement} />
 
-    <h2 class="text-xl mt-4 font-bold">Skills</h2>
+    <h2 class="font-display print:font-sans text-2xl mt-10 print:mt-4 font-bold border-t border-stone-200 print:border-0 pt-8 print:pt-0">Skills</h2>
 
     <div class="flex flex-wrap">
       <ul class="min-w-[50%] p-0 m-0 list-disc">
@@ -70,7 +70,7 @@ import pdfIcon from "../../images/icon_pdf.svg";
       </ul>
     </div>
 
-    <h2 class="text-xl mt-4 font-bold mb-1">Experience</h2>
+    <h2 class="font-display print:font-sans text-2xl mt-10 print:mt-4 font-bold mb-2 border-t border-stone-200 print:border-0 pt-8 print:pt-0">Experience</h2>
 
     <h3 class="text-emerald-900 text-lg font-bold">Forge Holiday Group, 2022 - Present</h3>
     <div class="italic">Lead Developer</div>
@@ -201,7 +201,7 @@ import pdfIcon from "../../images/icon_pdf.svg";
       </ul>
     </div>
 
-    <h2 class="text-xl mt-4 font-bold mb-1">Education</h2>
+    <h2 class="font-display print:font-sans text-2xl mt-10 print:mt-4 font-bold mb-2 border-t border-stone-200 print:border-0 pt-8 print:pt-0">Education</h2>
 
     <h3 class="text-emerald-900 text-lg font-bold">University of Chester, 2007 - 2010</h3>
     <div>BSc Computer Science - first-class honors</div>

--- a/src/pages/cv/frontend.astro
+++ b/src/pages/cv/frontend.astro
@@ -26,7 +26,7 @@ import pdfIcon from "../../images/icon_pdf.svg";
       </a>
     </div>
 
-    <h1 class="text-[2em] mt-[0.67em] mb-0">Matthew Mincher</h1>
+    <h1 class="font-display print:font-sans text-[2em] mt-[0.67em] mb-0">Matthew Mincher</h1>
     <div class="mt-1">
       www.matthewmincher.dev
     </div>
@@ -41,10 +41,10 @@ import pdfIcon from "../../images/icon_pdf.svg";
     </div>
     <div class="mt-1">Chester, UK</div>
 
-    <h2 class="text-xl mt-4 mb-1 font-bold">Personal Statement</h2>
+    <h2 class="font-display print:font-sans text-2xl mt-10 print:mt-4 mb-2 font-bold border-t border-stone-200 print:border-0 pt-8 print:pt-0">Personal Statement</h2>
     <Fragment set:html={personalStatement} />
 
-    <h2 class="text-xl mt-4 font-bold">Skills</h2>
+    <h2 class="font-display print:font-sans text-2xl mt-10 print:mt-4 font-bold border-t border-stone-200 print:border-0 pt-8 print:pt-0">Skills</h2>
 
     <div class="flex flex-wrap">
       <ul class="min-w-[50%] p-0 m-0 list-disc">
@@ -69,7 +69,7 @@ import pdfIcon from "../../images/icon_pdf.svg";
       </ul>
     </div>
 
-    <h2 class="text-xl mt-4 font-bold mb-1">Experience</h2>
+    <h2 class="font-display print:font-sans text-2xl mt-10 print:mt-4 font-bold mb-2 border-t border-stone-200 print:border-0 pt-8 print:pt-0">Experience</h2>
 
     <h3 class="text-emerald-900 text-lg font-bold">Forge Holiday Group, 2022 - Present</h3>
     <div class="italic">Lead Developer</div>
@@ -195,7 +195,7 @@ import pdfIcon from "../../images/icon_pdf.svg";
       </ul>
     </div>
 
-    <h2 class="text-xl mt-4 font-bold mb-1">Education</h2>
+    <h2 class="font-display print:font-sans text-2xl mt-10 print:mt-4 font-bold mb-2 border-t border-stone-200 print:border-0 pt-8 print:pt-0">Education</h2>
 
     <h3 class="text-emerald-900 text-lg font-bold">University of Chester, 2007 - 2010</h3>
     <div>BSc Computer Science - first-class honors</div>


### PR DESCRIPTION
## Summary
- Add `font-display` (Sora) to h1 and h2 headings on backend and frontend CV pages to match the main full stack CV
- Increase heading size from `text-xl` to `text-2xl`
- Add section divider borders and spacing consistent with the main CV

## Test plan
- [ ] Compare /cv, /cv/backend, and /cv/frontend — headings should use the same font and styling
- [ ] Verify print styles still use system font (`print:font-sans`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)