### PR TITLE
Use pages_build_output_dir in wrangler config

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,7 +1,5 @@
 {
   "name": "matthewmincherdev",
   "compatibility_date": "2026-05-06",
-  "assets": {
-    "directory": "./dist"
-  }
+  "pages_build_output_dir": "./dist"
 }


### PR DESCRIPTION
## Summary
- Switches wrangler.jsonc from `assets.directory` to `pages_build_output_dir` so Cloudflare recognizes this as a Pages project with Functions support
- This enables setting environment variables (like `LASTFM_API_KEY`) in the Cloudflare dashboard

## Test plan
- [ ] Verify Cloudflare Pages deployment still works
- [ ] Confirm environment variables can be set in the Cloudflare dashboard
- [ ] Verify the `/api/lastfm` Pages Function is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)