### PR TITLE
Switch to pages_build_output_dir for Pages Functions

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4,30 +4,20 @@ interface Env {
   LASTFM_API_KEY: string;
 }
 
-interface PagesContext {
-  request: Request;
-  env: Env;
-  waitUntil(promise: Promise<unknown>): void;
-}
-
 const LASTFM_USER = "matthewmincher";
 const LASTFM_API_BASE = "https://ws.audioscrobbler.com/2.0/";
 const CACHE_TTL_SECONDS = 120;
 
-export async function onRequestGet(
-  context: PagesContext,
-): Promise<Response> {
+async function handleLastfm(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
   const cache = caches.default;
-  const cacheKey = new Request(new URL(context.request.url).toString());
+  const cacheKey = new Request(new URL(request.url).toString());
 
   const cached = await cache.match(cacheKey);
   if (cached) return cached;
 
-  const apiKey = context.env.LASTFM_API_KEY;
+  const apiKey = env.LASTFM_API_KEY;
   if (!apiKey) {
-    return new Response(JSON.stringify({ tracks: [] }), {
-      headers: { "Content-Type": "application/json" },
-    });
+    return Response.json({ tracks: [] });
   }
 
   const url = `${LASTFM_API_BASE}?method=user.getrecenttracks&user=${LASTFM_USER}&api_key=${apiKey}&format=json&limit=10`;
@@ -35,9 +25,7 @@ export async function onRequestGet(
   try {
     const res = await fetch(url);
     if (!res.ok) {
-      return new Response(JSON.stringify({ tracks: [] }), {
-        headers: { "Content-Type": "application/json" },
-      });
+      return Response.json({ tracks: [] });
     }
 
     const data: any = await res.json();
@@ -71,12 +59,22 @@ export async function onRequestGet(
       },
     });
 
-    context.waitUntil(cache.put(cacheKey, response.clone()));
+    ctx.waitUntil(cache.put(cacheKey, response.clone()));
 
     return response;
   } catch {
-    return new Response(JSON.stringify({ tracks: [] }), {
-      headers: { "Content-Type": "application/json" },
-    });
+    return Response.json({ tracks: [] });
   }
 }
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const { pathname } = new URL(request.url);
+
+    if (pathname === "/api/lastfm" && request.method === "GET") {
+      return handleLastfm(request, env, ctx);
+    }
+
+    return new Response("Not Found", { status: 404 });
+  },
+} satisfies ExportedHandler<Env>;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,5 +1,8 @@
 {
   "name": "matthewmincherdev",
   "compatibility_date": "2026-05-06",
-  "pages_build_output_dir": "./dist"
+  "main": "src/worker.ts",
+  "assets": {
+    "directory": "./dist"
+  }
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,7 +1,5 @@
 {
   "name": "matthewmincherdev",
   "compatibility_date": "2026-05-06",
-  "assets": {
-    "directory": "./dist"
-  }
+  "pages_build_output_dir": "./dist"
 }


### PR DESCRIPTION
## Summary
- Switches wrangler.jsonc from `assets.directory` to `pages_build_output_dir` to enable Pages Functions and environment variables

## Dashboard settings
- **Build command**: `npm run build`
- **Deploy command**: `npx wrangler pages deploy ./dist`
- **Non-production deploy command**: `npx wrangler pages deploy ./dist`

🤖 Generated with [Claude Code](https://claude.com/claude-code)