### PR TITLE
Switch from Pages to Workers deployment

### DIFF
--- a/.github/workflows/sync-secrets.yml
+++ b/.github/workflows/sync-secrets.yml
@@ -1,4 +1,4 @@
-name: Sync Secrets to Cloudflare Pages
+name: Sync Secrets to Cloudflare Worker
 
 on:
   push:
@@ -22,8 +22,8 @@ jobs:
       - name: Install wrangler
         run: npm install -g wrangler
 
-      - name: Propagate Last.fm API key to Cloudflare Pages
-        run: echo "$LASTFM_API_KEY" | wrangler pages secret put LASTFM_API_KEY --project-name matthewmincherdev
+      - name: Propagate Last.fm API key to Cloudflare Worker
+        run: echo "$LASTFM_API_KEY" | wrangler secret put LASTFM_API_KEY --name matthewmincherdev
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
- Replace Pages Function (`functions/api/lastfm.ts`) with a Worker entry point (`src/worker.ts`) and configure wrangler with `main` + `assets.directory`
- Update secret sync workflow to use `wrangler secret put` instead of Pages-specific `wrangler pages secret put`

## Test plan
- [x] `npm run build` succeeds
- [x] `wrangler deploy --dry-run` validates config and reads assets
- [ ] Verify `/api/lastfm` returns track data after deploy
- [ ] Verify static site pages load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)