### PR TITLE
Add projects section with home climate dashboard

### DIFF
--- a/.github/workflows/sync-secrets.yml
+++ b/.github/workflows/sync-secrets.yml
@@ -28,3 +28,17 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
+
+      - name: Propagate InfluxDB token to Cloudflare Worker
+        run: echo "$INFLUXDB_TOKEN" | wrangler secret put INFLUXDB_TOKEN --name matthewmincherdev
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          INFLUXDB_TOKEN: ${{ secrets.INFLUXDB_TOKEN }}
+
+      - name: Propagate InfluxDB org to Cloudflare Worker
+        run: echo "$INFLUXDB_ORG" | wrangler secret put INFLUXDB_ORG --name matthewmincherdev
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          INFLUXDB_ORG: ${{ secrets.INFLUXDB_ORG }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "fast-xml-parser": "^5.7.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "recharts": "^3.9.0",
         "tailwindcss": "^4.0.0",
         "validator": "^13.6.0"
       },
@@ -1585,6 +1586,42 @@
         "node": ">=10"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -2038,6 +2075,18 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
@@ -2354,6 +2403,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2442,6 +2554,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/validator": {
@@ -3386,6 +3504,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
@@ -3412,6 +3651,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -3661,6 +3906,16 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.48.1.tgz",
+      "integrity": "sha512-wfnXlwd5I75eXRtdD2vuEs50xHHESECDsGD7yiQnfFVNoa5522NwXEbmgo98LfiukSQHs+mBM7/YG3qKJB9/mQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -4346,6 +4601,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4361,6 +4626,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ip-address": {
@@ -6319,6 +6593,36 @@
         "react": "^19.2.6"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -6339,6 +6643,51 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.9.0.tgz",
+      "integrity": "sha512-dCEcE9y20c8H2tkVeByrAXhhnBJk6/QLbxKmn+dJUptOfc5NMjwRh1jo0vZPRLD+5dMrHrP+hPEsfbGBMfnf5Q==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.2.0",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/regex": {
@@ -6516,6 +6865,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -7066,6 +7421,12 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyclip": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.12.tgz",
@@ -7469,6 +7830,15 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7524,6 +7894,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "fast-xml-parser": "^5.7.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "recharts": "^3.9.0",
     "tailwindcss": "^4.0.0",
     "validator": "^13.6.0"
   },

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -4,6 +4,7 @@ const pathname = Astro.url.pathname;
 const isHome = pathname === "/";
 const isCv = pathname.startsWith("/cv");
 const isBlog = pathname.startsWith("/blog");
+const isProjects = pathname.startsWith("/projects");
 const isContact = pathname.startsWith("/contact");
 
 const linkClass =
@@ -40,6 +41,14 @@ const contactActiveClass = "text-stone-100 bg-emerald-900";
           class:list={[linkClass, isBlog && activeClass]}
         >
           Blog
+        </a>
+      </li>
+      <li class="flex flex-grow-0 flex-shrink flex-row">
+        <a
+          href="/projects/"
+          class:list={[linkClass, isProjects && activeClass]}
+        >
+          Projects
         </a>
       </li>
     </ul>

--- a/src/components/climate/ClimateCharts.tsx
+++ b/src/components/climate/ClimateCharts.tsx
@@ -1,0 +1,494 @@
+import { useState, useEffect, useMemo } from "react";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from "recharts";
+
+const RANGES = ["1h", "24h", "7d", "30d"] as const;
+type Range = (typeof RANGES)[number];
+
+const RANGE_LABELS: Record<Range, string> = {
+  "1h": "1 Hour",
+  "24h": "24 Hours",
+  "7d": "7 Days",
+  "30d": "30 Days",
+};
+
+interface ClimateDataPoint {
+  time: string;
+  entityId: string;
+  deviceClass: string;
+  value: number;
+}
+
+interface RoomConfig {
+  id: string;
+  label: string;
+  tempEntityId: string;
+  humidityEntityId: string;
+  color: string;
+}
+
+interface FloorConfig {
+  label: string;
+  rooms: RoomConfig[];
+}
+
+const FLOORS: FloorConfig[] = [
+  {
+    label: "Upstairs",
+    rooms: [
+      {
+        id: "study",
+        label: "Study",
+        tempEntityId: "study_temperature",
+        humidityEntityId: "study_humidity",
+        color: "#059669",
+      },
+      {
+        id: "bedroom",
+        label: "Bedroom",
+        tempEntityId: "bedroom_temperature",
+        humidityEntityId: "bedroom_humidity",
+        color: "#0891b2",
+      },
+    ],
+  },
+  {
+    label: "Downstairs",
+    rooms: [
+      {
+        id: "lounge",
+        label: "Living Room",
+        tempEntityId: "lounge_temperature",
+        humidityEntityId: "lounge_humidity",
+        color: "#7c3aed",
+      },
+    ],
+  },
+];
+
+interface ChartDataPoint {
+  time: number;
+  value: number | null;
+  prevValue: number | null;
+}
+
+function buildChartData(
+  current: ClimateDataPoint[],
+  previous: ClimateDataPoint[] | null,
+  entityId: string,
+  range: Range,
+): ChartDataPoint[] {
+  const currentFiltered = current.filter((p) => p.entityId === entityId);
+
+  const timeMap = new Map<number, ChartDataPoint>();
+
+  for (const point of currentFiltered) {
+    const t = new Date(point.time).getTime();
+    timeMap.set(t, { time: t, value: point.value, prevValue: null });
+  }
+
+  if (previous) {
+    const prevFiltered = previous.filter((p) => p.entityId === entityId);
+    const rangeMs = {
+      "1h": 3600_000,
+      "24h": 86400_000,
+      "7d": 604800_000,
+      "30d": 2592000_000,
+    }[range];
+
+    for (const point of prevFiltered) {
+      const originalTime = new Date(point.time).getTime();
+      const shiftedTime = originalTime + rangeMs;
+      const closest = findClosestTime(timeMap, shiftedTime);
+      if (closest !== null) {
+        const entry = timeMap.get(closest)!;
+        entry.prevValue = point.value;
+      }
+    }
+  }
+
+  return Array.from(timeMap.values()).sort((a, b) => a.time - b.time);
+}
+
+function findClosestTime(
+  timeMap: Map<number, ChartDataPoint>,
+  target: number,
+): number | null {
+  let closest: number | null = null;
+  let minDiff = Infinity;
+  for (const t of timeMap.keys()) {
+    const diff = Math.abs(t - target);
+    if (diff < minDiff) {
+      minDiff = diff;
+      closest = t;
+    }
+  }
+  if (closest !== null && minDiff < 600_000) return closest;
+  return null;
+}
+
+function formatTime(timestamp: number, range: Range): string {
+  const date = new Date(timestamp);
+  if (range === "1h" || range === "24h") {
+    return date.toLocaleTimeString("en-GB", {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+  return date.toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatTooltipTime(timestamp: number): string {
+  return new Date(timestamp).toLocaleString("en-GB", {
+    day: "numeric",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function getLatestReading(
+  data: ClimateDataPoint[],
+  entityId: string,
+): number | null {
+  const filtered = data.filter((p) => p.entityId === entityId);
+  if (filtered.length === 0) return null;
+  const latest = filtered.reduce((a, b) =>
+    new Date(a.time) > new Date(b.time) ? a : b,
+  );
+  return Math.round(latest.value * 10) / 10;
+}
+
+interface RoomChartProps {
+  data: ChartDataPoint[];
+  label: string;
+  unit: string;
+  color: string;
+  range: Range;
+  compare: boolean;
+}
+
+function RoomChart({ data, label, unit, color, range, compare }: RoomChartProps) {
+  if (data.length === 0) {
+    return (
+      <div className="h-48 flex items-center justify-center text-gray-400 text-sm">
+        No data available
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <p className="text-sm text-gray-500 mb-2">{label}</p>
+      <ResponsiveContainer width="100%" height={200}>
+        <LineChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+          <XAxis
+            dataKey="time"
+            tickFormatter={(t) => formatTime(t, range)}
+            stroke="#9ca3af"
+            fontSize={11}
+            minTickGap={40}
+          />
+          <YAxis
+            stroke="#9ca3af"
+            fontSize={11}
+            tickFormatter={(v) => `${v}${unit}`}
+            width={50}
+          />
+          <Tooltip
+            labelFormatter={formatTooltipTime}
+            formatter={(value: number) => [
+              `${Math.round(value * 10) / 10}${unit}`,
+            ]}
+            contentStyle={{
+              backgroundColor: "#fafaf9",
+              border: "1px solid #e7e5e4",
+              borderRadius: "8px",
+              fontSize: "13px",
+            }}
+          />
+          <Line
+            dataKey="value"
+            stroke={color}
+            strokeWidth={2}
+            dot={false}
+            name="Current"
+            connectNulls
+          />
+          {compare && (
+            <Line
+              dataKey="prevValue"
+              stroke={color}
+              strokeWidth={1.5}
+              strokeDasharray="5 5"
+              strokeOpacity={0.4}
+              dot={false}
+              name="Previous"
+              connectNulls
+            />
+          )}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+interface StatCardProps {
+  label: string;
+  temperature: number | null;
+  humidity: number | null;
+  color: string;
+}
+
+function StatCard({ label, temperature, humidity, color }: StatCardProps) {
+  return (
+    <div className="bg-stone-100 border border-stone-200 rounded-xl p-4">
+      <div className="flex items-center gap-2 mb-2">
+        <div
+          className="w-2.5 h-2.5 rounded-full"
+          style={{ backgroundColor: color }}
+        />
+        <span className="text-sm font-medium text-gray-700">{label}</span>
+      </div>
+      <div className="flex gap-4">
+        <div>
+          <span className="text-2xl font-bold text-gray-900">
+            {temperature !== null ? `${temperature}°` : "—"}
+          </span>
+          <span className="text-xs text-gray-400 ml-1">C</span>
+        </div>
+        <div>
+          <span className="text-2xl font-bold text-gray-900">
+            {humidity !== null ? `${humidity}%` : "—"}
+          </span>
+          <span className="text-xs text-gray-400 ml-1">RH</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ClimateCharts() {
+  const [range, setRange] = useState<Range>("24h");
+  const [compare, setCompare] = useState(false);
+  const [data, setData] = useState<{
+    current: ClimateDataPoint[];
+    previous: ClimateDataPoint[] | null;
+  }>({ current: [], previous: null });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(false);
+
+    const params = new URLSearchParams({ range });
+    if (compare && range !== "30d") {
+      params.set("compare", "true");
+    }
+
+    fetch(`/api/climate?${params}`)
+      .then((res) => {
+        if (!res.ok) throw new Error();
+        return res.json();
+      })
+      .then((json) => {
+        setData(json);
+        setLoading(false);
+      })
+      .catch(() => {
+        setError(true);
+        setLoading(false);
+      });
+  }, [range, compare]);
+
+  const showCompare = compare && range !== "30d";
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-center gap-3 mb-8">
+        <div className="flex bg-stone-100 border border-stone-200 rounded-lg p-1">
+          {RANGES.map((r) => (
+            <button
+              key={r}
+              onClick={() => setRange(r)}
+              className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                range === r
+                  ? "bg-emerald-600 text-white"
+                  : "text-gray-600 hover:text-gray-900"
+              }`}
+            >
+              {RANGE_LABELS[r]}
+            </button>
+          ))}
+        </div>
+
+        {range !== "30d" && (
+          <label className="flex items-center gap-2 text-sm text-gray-600 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={compare}
+              onChange={(e) => setCompare(e.target.checked)}
+              className="accent-emerald-600"
+            />
+            Compare to previous period
+          </label>
+        )}
+      </div>
+
+      {loading && (
+        <div className="flex items-center justify-center py-20">
+          <div className="w-6 h-6 border-2 border-emerald-500 border-t-transparent rounded-full animate-spin" />
+        </div>
+      )}
+
+      {error && (
+        <div className="text-center py-20 text-gray-500">
+          Failed to load climate data. Please try again later.
+        </div>
+      )}
+
+      {!loading && !error && (
+        <ClimateContent
+          data={data}
+          range={range}
+          compare={showCompare}
+        />
+      )}
+    </div>
+  );
+}
+
+function ClimateContent({
+  data,
+  range,
+  compare,
+}: {
+  data: { current: ClimateDataPoint[]; previous: ClimateDataPoint[] | null };
+  range: Range;
+  compare: boolean;
+}) {
+  const allRooms = FLOORS.flatMap((f) => f.rooms);
+
+  const statCards = useMemo(
+    () =>
+      allRooms.map((room) => ({
+        room,
+        temperature: getLatestReading(data.current, room.tempEntityId),
+        humidity: getLatestReading(data.current, room.humidityEntityId),
+      })),
+    [data.current],
+  );
+
+  return (
+    <>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-10">
+        {statCards.map(({ room, temperature, humidity }) => (
+          <StatCard
+            key={room.id}
+            label={room.label}
+            temperature={temperature}
+            humidity={humidity}
+            color={room.color}
+          />
+        ))}
+      </div>
+
+      {FLOORS.map((floor) => (
+        <div key={floor.label} className="mb-10">
+          <h3 className="font-display text-lg font-bold text-gray-700 mb-4">
+            {floor.label}
+          </h3>
+          <div className="space-y-8">
+            {floor.rooms.map((room) => (
+              <RoomCharts
+                key={room.id}
+                room={room}
+                data={data}
+                range={range}
+                compare={compare}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}
+
+function RoomCharts({
+  room,
+  data,
+  range,
+  compare,
+}: {
+  room: RoomConfig;
+  data: { current: ClimateDataPoint[]; previous: ClimateDataPoint[] | null };
+  range: Range;
+  compare: boolean;
+}) {
+  const tempData = useMemo(
+    () =>
+      buildChartData(
+        data.current,
+        compare ? data.previous : null,
+        room.tempEntityId,
+        range,
+      ),
+    [data, room.tempEntityId, range, compare],
+  );
+
+  const humidityData = useMemo(
+    () =>
+      buildChartData(
+        data.current,
+        compare ? data.previous : null,
+        room.humidityEntityId,
+        range,
+      ),
+    [data, room.humidityEntityId, range, compare],
+  );
+
+  return (
+    <div className="bg-white border border-stone-200 rounded-xl p-5">
+      <h4 className="font-display font-bold text-gray-800 mb-4 flex items-center gap-2">
+        <span
+          className="w-2.5 h-2.5 rounded-full inline-block"
+          style={{ backgroundColor: room.color }}
+        />
+        {room.label}
+      </h4>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <RoomChart
+          data={tempData}
+          label="Temperature"
+          unit="°C"
+          color={room.color}
+          range={range}
+          compare={compare}
+        />
+        <RoomChart
+          data={humidityData}
+          label="Relative Humidity"
+          unit="%"
+          color={room.color}
+          range={range}
+          compare={compare}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/climate/ClimateCharts.tsx
+++ b/src/components/climate/ClimateCharts.tsx
@@ -296,7 +296,7 @@ export default function ClimateCharts() {
   const [error, setError] = useState(false);
 
   useEffect(() => {
-    fetch("/api/climate?range=1h")
+    fetch("/api/climate?range=24h")
       .then((res) => {
         if (!res.ok) throw new Error();
         return res.json();

--- a/src/components/climate/ClimateCharts.tsx
+++ b/src/components/climate/ClimateCharts.tsx
@@ -291,7 +291,8 @@ export default function ClimateCharts() {
     previous: ClimateDataPoint[] | null;
   }>({ current: [], previous: null });
   const [latestData, setLatestData] = useState<ClimateDataPoint[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [initialLoad, setInitialLoad] = useState(true);
+  const [fetching, setFetching] = useState(false);
   const [error, setError] = useState(false);
 
   useEffect(() => {
@@ -307,7 +308,7 @@ export default function ClimateCharts() {
   }, []);
 
   useEffect(() => {
-    setLoading(true);
+    setFetching(true);
     setError(false);
 
     const params = new URLSearchParams({ range });
@@ -322,11 +323,13 @@ export default function ClimateCharts() {
       })
       .then((json) => {
         setData(json);
-        setLoading(false);
+        setInitialLoad(false);
+        setFetching(false);
       })
       .catch(() => {
         setError(true);
-        setLoading(false);
+        setInitialLoad(false);
+        setFetching(false);
       });
   }, [range, compare]);
 
@@ -386,24 +389,29 @@ export default function ClimateCharts() {
         )}
       </div>
 
-      {loading && (
+      {initialLoad ? (
         <div className="flex items-center justify-center py-20">
           <div className="w-6 h-6 border-2 border-emerald-500 border-t-transparent rounded-full animate-spin" />
         </div>
-      )}
-
-      {error && (
+      ) : error ? (
         <div className="text-center py-20 text-gray-500">
           Failed to load climate data. Please try again later.
         </div>
-      )}
-
-      {!loading && !error && (
-        <ChartContent
-          data={data}
-          range={range}
-          compare={showCompare}
-        />
+      ) : (
+        <div className="relative">
+          {fetching && (
+            <div className="absolute top-0 right-0 z-10">
+              <div className="w-4 h-4 border-2 border-emerald-500 border-t-transparent rounded-full animate-spin" />
+            </div>
+          )}
+          <div className={fetching ? "opacity-60 transition-opacity" : "transition-opacity"}>
+            <ChartContent
+              data={data}
+              range={range}
+              compare={showCompare}
+            />
+          </div>
+        </div>
       )}
     </div>
   );

--- a/src/components/climate/ClimateCharts.tsx
+++ b/src/components/climate/ClimateCharts.tsx
@@ -281,6 +281,8 @@ function StatCard({ label, temperature, humidity, color }: StatCardProps) {
   );
 }
 
+const ALL_ROOMS = FLOORS.flatMap((f) => f.rooms);
+
 export default function ClimateCharts() {
   const [range, setRange] = useState<Range>("24h");
   const [compare, setCompare] = useState(false);
@@ -288,8 +290,21 @@ export default function ClimateCharts() {
     current: ClimateDataPoint[];
     previous: ClimateDataPoint[] | null;
   }>({ current: [], previous: null });
+  const [latestData, setLatestData] = useState<ClimateDataPoint[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+
+  useEffect(() => {
+    fetch("/api/climate?range=1h")
+      .then((res) => {
+        if (!res.ok) throw new Error();
+        return res.json();
+      })
+      .then((json) => {
+        setLatestData(json.current);
+      })
+      .catch(() => {});
+  }, []);
 
   useEffect(() => {
     setLoading(true);
@@ -317,8 +332,30 @@ export default function ClimateCharts() {
 
   const showCompare = compare && range !== "30d";
 
+  const statCards = useMemo(
+    () =>
+      ALL_ROOMS.map((room) => ({
+        room,
+        temperature: getLatestReading(latestData, room.tempEntityId),
+        humidity: getLatestReading(latestData, room.humidityEntityId),
+      })),
+    [latestData],
+  );
+
   return (
     <div>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
+        {statCards.map(({ room, temperature, humidity }) => (
+          <StatCard
+            key={room.id}
+            label={room.label}
+            temperature={temperature}
+            humidity={humidity}
+            color={room.color}
+          />
+        ))}
+      </div>
+
       <div className="flex flex-wrap items-center gap-3 mb-8">
         <div className="flex bg-stone-100 border border-stone-200 rounded-lg p-1">
           {RANGES.map((r) => (
@@ -362,7 +399,7 @@ export default function ClimateCharts() {
       )}
 
       {!loading && !error && (
-        <ClimateContent
+        <ChartContent
           data={data}
           range={range}
           compare={showCompare}
@@ -372,7 +409,7 @@ export default function ClimateCharts() {
   );
 }
 
-function ClimateContent({
+function ChartContent({
   data,
   range,
   compare,
@@ -381,32 +418,8 @@ function ClimateContent({
   range: Range;
   compare: boolean;
 }) {
-  const allRooms = FLOORS.flatMap((f) => f.rooms);
-
-  const statCards = useMemo(
-    () =>
-      allRooms.map((room) => ({
-        room,
-        temperature: getLatestReading(data.current, room.tempEntityId),
-        humidity: getLatestReading(data.current, room.humidityEntityId),
-      })),
-    [data.current],
-  );
-
   return (
     <>
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-10">
-        {statCards.map(({ room, temperature, humidity }) => (
-          <StatCard
-            key={room.id}
-            label={room.label}
-            temperature={temperature}
-            humidity={humidity}
-            color={room.color}
-          />
-        ))}
-      </div>
-
       {FLOORS.map((floor) => (
         <div key={floor.label} className="mb-10">
           <h3 className="font-display text-lg font-bold text-gray-700 mb-4">

--- a/src/components/climate/ClimateCharts.tsx
+++ b/src/components/climate/ClimateCharts.tsx
@@ -227,6 +227,7 @@ function RoomChart({ data, label, unit, color, range, compare }: RoomChartProps)
             dot={false}
             name="Current"
             connectNulls
+            isAnimationActive={false}
           />
           {compare && (
             <Line

--- a/src/pages/projects/home-climate/index.astro
+++ b/src/pages/projects/home-climate/index.astro
@@ -1,0 +1,27 @@
+---
+import Layout from "../../../layouts/Layout.astro";
+import ClimateCharts from "../../../components/climate/ClimateCharts";
+---
+
+<Layout pageTitle="Home Climate">
+  <div class="w-full mx-auto max-w-screen-xl px-5 py-10">
+    <div class="mb-2">
+      <a
+        href="/projects/"
+        class="text-sm text-emerald-600 hover:text-emerald-500 transition-colors"
+      >
+        &larr; Projects
+      </a>
+    </div>
+
+    <h1 class="font-display text-emerald-500 text-4xl font-bold mb-3">
+      Home Climate
+    </h1>
+    <p class="text-gray-500 mb-10 max-w-2xl">
+      Live temperature and humidity readings from around the house, tracked with
+      Home Assistant sensors and stored in InfluxDB.
+    </p>
+
+    <ClimateCharts client:load />
+  </div>
+</Layout>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,0 +1,44 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import { Icon } from "astro-icon/components";
+
+const projects = [
+  {
+    title: "Home Climate",
+    description:
+      "Live temperature and humidity monitoring across the house using Home Assistant sensors and InfluxDB.",
+    href: "/projects/home-climate/",
+    icon: "fa6-solid:temperature-half",
+  },
+];
+---
+
+<Layout pageTitle="Projects">
+  <div class="w-full mx-auto max-w-screen-xl px-5 py-10">
+    <h1 class="font-display text-emerald-500 text-4xl font-bold mb-10">
+      Projects
+    </h1>
+
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+      {projects.map((project) => (
+        <a
+          href={project.href}
+          class="group block bg-stone-100 border border-stone-200 rounded-xl p-6 transition-all duration-200 hover:border-emerald-500/30 hover:shadow-sm"
+        >
+          <div class="w-10 h-10 bg-emerald-500/10 rounded-lg flex items-center justify-center mb-4">
+            <Icon
+              name={project.icon}
+              class="w-5 h-5 text-emerald-600"
+            />
+          </div>
+          <h2 class="font-display text-lg font-bold text-emerald-900 group-hover:text-emerald-500 transition-colors mb-2">
+            {project.title}
+          </h2>
+          <p class="text-gray-500 text-sm leading-relaxed">
+            {project.description}
+          </p>
+        </a>
+      ))}
+    </div>
+  </div>
+</Layout>

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -37,7 +37,8 @@ function buildFluxQuery(range: string, start: string, stop?: string): string {
   let query = `from(bucket: "${INFLUXDB_BUCKET}")
   |> range(start: ${start}${stopClause})
   |> filter(fn: (r) => r._field == "value")
-  |> filter(fn: (r) => r.device_class_str == "temperature" or r.device_class_str == "humidity")`;
+  |> filter(fn: (r) => r._measurement == "°C" or r._measurement == "%")
+  |> filter(fn: (r) => r.domain == "sensor")`;
 
   if (config.aggregate) {
     query += `\n  |> aggregateWindow(every: ${config.aggregate}, fn: mean, createEmpty: false)`;
@@ -72,7 +73,9 @@ function parseFluxCSV(csv: string): ClimateDataPoint[] {
     const time = row["_time"];
     const value = parseFloat(row["_value"]);
     const entityId = row["entity_id"];
-    const deviceClass = row["device_class_str"];
+    const measurement = row["_measurement"];
+    const deviceClass =
+      measurement === "°C" ? "temperature" : measurement === "%" ? "humidity" : null;
 
     if (time && !isNaN(value) && entityId && deviceClass) {
       points.push({ time, entityId, deviceClass, value });

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2,13 +2,162 @@ declare const caches: CacheStorage & { default: Cache };
 
 interface Env {
   LASTFM_API_KEY: string;
+  INFLUXDB_TOKEN: string;
+  INFLUXDB_ORG: string;
 }
 
 const LASTFM_USER = "matthewmincher";
 const LASTFM_API_BASE = "https://ws.audioscrobbler.com/2.0/";
 const CACHE_TTL_SECONDS = 120;
 
-async function handleLastfm(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+const INFLUXDB_URL = "https://eu-central-1-1.aws.cloud2.influxdata.com";
+const INFLUXDB_BUCKET = "home-climate";
+
+const RANGE_CONFIG: Record<
+  string,
+  { fluxRange: string; aggregate?: string; cacheTTL: number; compareRange?: string; compareStop?: string }
+> = {
+  "1h": { fluxRange: "-1h", cacheTTL: 300, compareRange: "-2h", compareStop: "-1h" },
+  "24h": { fluxRange: "-24h", cacheTTL: 600, compareRange: "-48h", compareStop: "-24h" },
+  "7d": { fluxRange: "-7d", aggregate: "30m", cacheTTL: 1800, compareRange: "-14d", compareStop: "-7d" },
+  "30d": { fluxRange: "-30d", aggregate: "1h", cacheTTL: 3600 },
+};
+
+interface ClimateDataPoint {
+  time: string;
+  entityId: string;
+  deviceClass: string;
+  value: number;
+}
+
+function buildFluxQuery(range: string, start: string, stop?: string): string {
+  const config = RANGE_CONFIG[range];
+  const stopClause = stop ? `, stop: ${stop}` : "";
+
+  let query = `from(bucket: "${INFLUXDB_BUCKET}")
+  |> range(start: ${start}${stopClause})
+  |> filter(fn: (r) => r._field == "value")
+  |> filter(fn: (r) => r.device_class_str == "temperature" or r.device_class_str == "humidity")`;
+
+  if (config.aggregate) {
+    query += `\n  |> aggregateWindow(every: ${config.aggregate}, fn: mean, createEmpty: false)`;
+  }
+
+  return query;
+}
+
+function parseFluxCSV(csv: string): ClimateDataPoint[] {
+  const lines = csv.split("\n");
+  const points: ClimateDataPoint[] = [];
+  let headers: string[] = [];
+
+  for (const line of lines) {
+    if (line.startsWith("#") || line.trim() === "") {
+      if (line.trim() === "") headers = [];
+      continue;
+    }
+
+    const values = line.split(",");
+
+    if (headers.length === 0) {
+      headers = values.map((h) => h.trim());
+      continue;
+    }
+
+    const row: Record<string, string> = {};
+    headers.forEach((h, i) => {
+      row[h] = values[i]?.trim() ?? "";
+    });
+
+    const time = row["_time"];
+    const value = parseFloat(row["_value"]);
+    const entityId = row["entity_id"];
+    const deviceClass = row["device_class_str"];
+
+    if (time && !isNaN(value) && entityId && deviceClass) {
+      points.push({ time, entityId, deviceClass, value });
+    }
+  }
+
+  return points;
+}
+
+async function queryInfluxDB(env: Env, query: string): Promise<string> {
+  const url = `${INFLUXDB_URL}/api/v2/query?org=${encodeURIComponent(env.INFLUXDB_ORG)}`;
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Token ${env.INFLUXDB_TOKEN}`,
+      "Content-Type": "application/vnd.flux",
+      Accept: "application/csv",
+    },
+    body: query,
+  });
+
+  if (!res.ok) {
+    throw new Error(`InfluxDB query failed: ${res.status}`);
+  }
+
+  return res.text();
+}
+
+async function handleClimate(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<Response> {
+  const cache = caches.default;
+  const cacheKey = new Request(new URL(request.url).toString());
+
+  const cached = await cache.match(cacheKey);
+  if (cached) return cached;
+
+  const url = new URL(request.url);
+  const range = url.searchParams.get("range") || "24h";
+  const compare = url.searchParams.get("compare") === "true";
+
+  const config = RANGE_CONFIG[range];
+  if (!config) {
+    return Response.json({ error: "Invalid range" }, { status: 400 });
+  }
+
+  if (!env.INFLUXDB_TOKEN || !env.INFLUXDB_ORG) {
+    return Response.json({ current: [], previous: null });
+  }
+
+  try {
+    const currentQuery = buildFluxQuery(range, config.fluxRange);
+    const currentCSV = await queryInfluxDB(env, currentQuery);
+    const current = parseFluxCSV(currentCSV);
+
+    let previous: ClimateDataPoint[] | null = null;
+    if (compare && config.compareRange && config.compareStop) {
+      const previousQuery = buildFluxQuery(range, config.compareRange, config.compareStop);
+      const previousCSV = await queryInfluxDB(env, previousQuery);
+      previous = parseFluxCSV(previousCSV);
+    }
+
+    const body = JSON.stringify({ current, previous });
+    const response = new Response(body, {
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": `public, s-maxage=${config.cacheTTL}`,
+      },
+    });
+
+    ctx.waitUntil(cache.put(cacheKey, response.clone()));
+    return response;
+  } catch {
+    return Response.json({ current: [], previous: null });
+  }
+}
+
+async function handleLastfm(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<Response> {
   const cache = caches.default;
   const cacheKey = new Request(new URL(request.url).toString());
 
@@ -60,7 +209,6 @@ async function handleLastfm(request: Request, env: Env, ctx: ExecutionContext): 
     });
 
     ctx.waitUntil(cache.put(cacheKey, response.clone()));
-
     return response;
   } catch {
     return Response.json({ tracks: [] });
@@ -68,11 +216,19 @@ async function handleLastfm(request: Request, env: Env, ctx: ExecutionContext): 
 }
 
 export default {
-  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+  async fetch(
+    request: Request,
+    env: Env,
+    ctx: ExecutionContext,
+  ): Promise<Response> {
     const { pathname } = new URL(request.url);
 
     if (pathname === "/api/lastfm" && request.method === "GET") {
       return handleLastfm(request, env, ctx);
+    }
+
+    if (pathname === "/api/climate" && request.method === "GET") {
+      return handleClimate(request, env, ctx);
     }
 
     return new Response("Not Found", { status: 404 });

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -99,7 +99,8 @@ async function queryInfluxDB(env: Env, query: string): Promise<string> {
   });
 
   if (!res.ok) {
-    throw new Error(`InfluxDB query failed: ${res.status}`);
+    const body = await res.text();
+    throw new Error(`InfluxDB query failed (${res.status}): ${body.slice(0, 200)}`);
   }
 
   return res.text();
@@ -126,7 +127,10 @@ async function handleClimate(
   }
 
   if (!env.INFLUXDB_TOKEN || !env.INFLUXDB_ORG) {
-    return Response.json({ current: [], previous: null });
+    return Response.json(
+      { error: "InfluxDB not configured", detail: `token=${!!env.INFLUXDB_TOKEN}, org=${!!env.INFLUXDB_ORG}` },
+      { status: 503 },
+    );
   }
 
   try {
@@ -151,8 +155,9 @@ async function handleClimate(
 
     ctx.waitUntil(cache.put(cacheKey, response.clone()));
     return response;
-  } catch {
-    return Response.json({ current: [], previous: null });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "Unknown error";
+    return Response.json({ error: "Failed to fetch climate data", detail: message }, { status: 502 });
   }
 }
 


### PR DESCRIPTION
Adds a projects section to the site, starting with a Home Climate dashboard that displays live temperature and humidity data from InfluxDB.

- `/projects/` index page with card grid
- `/projects/home-climate/` with per-room charts (Recharts) and current reading stat cards
- Worker endpoint `GET /api/climate` with range presets and caching
- "Projects" nav link after "Blog"
- `INFLUXDB_TOKEN` and `INFLUXDB_ORG` secrets synced via existing workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)