### PR TITLE
Remove duplicate API request for stat cards

### DIFF
--- a/src/components/climate/ClimateCharts.tsx
+++ b/src/components/climate/ClimateCharts.tsx
@@ -297,18 +297,6 @@ export default function ClimateCharts() {
   const [error, setError] = useState(false);
 
   useEffect(() => {
-    fetch("/api/climate?range=24h")
-      .then((res) => {
-        if (!res.ok) throw new Error();
-        return res.json();
-      })
-      .then((json) => {
-        setLatestData(json.current);
-      })
-      .catch(() => {});
-  }, []);
-
-  useEffect(() => {
     setFetching(true);
     setError(false);
 
@@ -324,6 +312,7 @@ export default function ClimateCharts() {
       })
       .then((json) => {
         setData(json);
+        setLatestData(json.current);
         setInitialLoad(false);
         setFetching(false);
       })


### PR DESCRIPTION
Populate latest readings from the chart data fetch instead of making a separate request on mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)