### PR TITLE
Add AI Engineering Lead role to CV

### DIFF
--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -82,7 +82,8 @@ import pdfIcon from "../images/icon_pdf.svg";
     <h2 class="font-display print:font-sans text-2xl mt-10 print:mt-4 font-bold mb-2 border-t border-stone-200 print:border-0 pt-8 print:pt-0">Experience</h2>
 
     <h3 class="text-emerald-900 text-lg font-bold">Forge Holiday Group, 2022 - Present</h3>
-    <div class="italic">Lead Developer</div>
+    <div class="italic">AI Engineering Lead - 2026</div>
+    <div class="italic">Lead Developer - 2022</div>
 
     <h3 class="text-emerald-900 font-bold mt-4">Code Fanatics, 2011 - 2021</h3>
     <div class="italic">Technical Director - 2014</div>

--- a/src/pages/cv/backend.astro
+++ b/src/pages/cv/backend.astro
@@ -73,7 +73,8 @@ import pdfIcon from "../../images/icon_pdf.svg";
     <h2 class="text-xl mt-4 font-bold mb-1">Experience</h2>
 
     <h3 class="text-emerald-900 text-lg font-bold">Forge Holiday Group, 2022 - Present</h3>
-    <div class="italic">Lead Developer</div>
+    <div class="italic">AI Engineering Lead - 2026</div>
+    <div class="italic">Lead Developer - 2022</div>
 
     <h3 class="text-emerald-900 font-bold mt-4">Code Fanatics, 2011 - 2021</h3>
     <div class="italic">Technical Director - 2014</div>

--- a/src/pages/cv/frontend.astro
+++ b/src/pages/cv/frontend.astro
@@ -72,7 +72,8 @@ import pdfIcon from "../../images/icon_pdf.svg";
     <h2 class="text-xl mt-4 font-bold mb-1">Experience</h2>
 
     <h3 class="text-emerald-900 text-lg font-bold">Forge Holiday Group, 2022 - Present</h3>
-    <div class="italic">Lead Developer</div>
+    <div class="italic">AI Engineering Lead - 2026</div>
+    <div class="italic">Lead Developer - 2022</div>
 
     <h3 class="text-emerald-900 font-bold mt-4">Code Fanatics, 2011 - 2021</h3>
     <div class="italic">Technical Director - 2014</div>


### PR DESCRIPTION
Update Forge Holiday Group entry across all three CV variants to show the transition to AI Engineering Lead from June 2026, matching the Code Fanatics role transition format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)