### PR TITLE
Add data point dots to climate charts

### DIFF
--- a/src/components/climate/ClimateCharts.tsx
+++ b/src/components/climate/ClimateCharts.tsx
@@ -224,7 +224,8 @@ function RoomChart({ data, label, unit, color, range, compare }: RoomChartProps)
             dataKey="value"
             stroke={color}
             strokeWidth={2}
-            dot={false}
+            dot={{ r: 2, fill: color, strokeWidth: 0 }}
+            activeDot={{ r: 4, strokeWidth: 0 }}
             name="Current"
             connectNulls
             isAnimationActive={false}


### PR DESCRIPTION
Show small dots at each data point on the climate charts, with a larger dot on hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)