### PR TITLE
Fix mobile nav overflow and wind speed text wrapping

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -1,4 +1,6 @@
 ---
+import { Icon } from "astro-icon/components";
+
 const pathname = Astro.url.pathname;
 
 const isHome = pathname === "/";
@@ -12,13 +14,13 @@ const linkClass =
 const activeClass = "text-emerald-500 border-b-emerald-500";
 
 const contactClass =
-  "self-center py-1 px-5 leading-6 font-bold decoration-0 text-emerald-900 border-2 border-emerald-900 rounded-2xl transition-all duration-200 ease-in-out hover:text-stone-100 hover:bg-emerald-900";
+  "self-center py-1 px-5 leading-6 font-bold decoration-0 text-emerald-900 border-2 border-emerald-900 rounded-2xl transition-all duration-200 ease-in-out hover:text-stone-100 hover:bg-emerald-900 whitespace-nowrap";
 const contactActiveClass = "text-stone-100 bg-emerald-900";
 ---
 
 <nav class="bg-stone-100 border-b border-stone-200 print:hidden">
   <div class="w-full mx-auto h-16 px-5 flex flex-grow flex-shrink-0 max-w-screen-xl">
-    <ul class="m-0 p-0 list-none flex gap-x-6">
+    <ul class="m-0 p-0 list-none flex gap-x-3 sm:gap-x-6">
       <li class="flex flex-grow-0 flex-shrink flex-row">
         <a
           href="/"
@@ -59,7 +61,8 @@ const contactActiveClass = "text-stone-100 bg-emerald-900";
           href="/contact/"
           class:list={[contactClass, isContact && contactActiveClass]}
         >
-          Get in Touch
+          <Icon name="fa6-solid:envelope" class="w-5 h-5 sm:hidden" />
+          <span class="hidden sm:inline">Get in Touch</span>
         </a>
       </li>
     </ul>

--- a/src/components/climate/ClimateCharts.tsx
+++ b/src/components/climate/ClimateCharts.tsx
@@ -371,7 +371,7 @@ function ForecastCard({ forecast }: { forecast: ForecastData | null }) {
           </div>
           <div>
             <span className="text-xs text-gray-400">Wind</span>
-            <p className="text-lg font-bold text-gray-900">
+            <p className="text-lg font-bold text-gray-900 whitespace-nowrap">
               {wind !== null ? `${wind} km/h` : "—"}
             </p>
           </div>


### PR DESCRIPTION
## Summary
- Replace "Get in Touch" button text with an envelope icon on mobile to prevent nav overflow
- Reduce nav link gap on small screens (`gap-x-3` → `gap-x-6` at `sm`)
- Add `whitespace-nowrap` to wind speed value to stop "km/h" wrapping to a second line

## Test plan
- [ ] Verify nav displays envelope icon on mobile and "Get in Touch" on desktop
- [ ] Verify wind speed "km/h" stays on one line on mobile
- [ ] Check nav spacing looks good at various breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)