### PR TITLE
Enable compare to previous period for 30-day range

### DIFF
--- a/src/components/climate/ClimateCharts.tsx
+++ b/src/components/climate/ClimateCharts.tsx
@@ -423,7 +423,7 @@ export default function ClimateCharts() {
     setError(false);
 
     const params = new URLSearchParams({ range });
-    if (compare && range !== "30d") {
+    if (compare) {
       params.set("compare", "true");
     }
 
@@ -446,8 +446,6 @@ export default function ClimateCharts() {
         setFetching(false);
       });
   }, [range, compare]);
-
-  const showCompare = compare && range !== "30d";
 
   const statCards = useMemo(
     () =>
@@ -495,18 +493,16 @@ export default function ClimateCharts() {
           ))}
         </div>
 
-        {range !== "30d" && (
-          <label className={`flex items-center gap-2 text-sm text-gray-600 select-none ${fetching ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}>
-            <input
-              type="checkbox"
-              checked={compare}
-              onChange={(e) => setCompare(e.target.checked)}
-              disabled={fetching}
-              className="accent-emerald-600"
-            />
-            Compare to previous period
-          </label>
-        )}
+        <label className={`flex items-center gap-2 text-sm text-gray-600 select-none ${fetching ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}>
+          <input
+            type="checkbox"
+            checked={compare}
+            onChange={(e) => setCompare(e.target.checked)}
+            disabled={fetching}
+            className="accent-emerald-600"
+          />
+          Compare to previous period
+        </label>
       </div>
 
       {initialLoad ? (
@@ -528,7 +524,7 @@ export default function ClimateCharts() {
             <ChartContent
               data={data}
               range={range}
-              compare={showCompare}
+              compare={compare}
             />
           </div>
         </div>

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -20,7 +20,7 @@ const RANGE_CONFIG: Record<
   "1h": { fluxRange: "-1h", cacheTTL: 300, compareRange: "-2h", compareStop: "-1h" },
   "24h": { fluxRange: "-24h", cacheTTL: 600, compareRange: "-48h", compareStop: "-24h" },
   "7d": { fluxRange: "-7d", aggregate: "30m", cacheTTL: 1800, compareRange: "-14d", compareStop: "-7d" },
-  "30d": { fluxRange: "-30d", aggregate: "1h", cacheTTL: 3600 },
+  "30d": { fluxRange: "-30d", aggregate: "1h", cacheTTL: 3600, compareRange: "-60d", compareStop: "-30d" },
 };
 
 interface ClimateDataPoint {
@@ -211,15 +211,17 @@ async function handleClimate(
 
   try {
     const currentQuery = buildFluxQuery(range, config.fluxRange);
-    const currentCSV = await queryInfluxDB(env, currentQuery);
-    const current = parseFluxCSV(currentCSV);
+    const previousQuery = compare && config.compareRange && config.compareStop
+      ? buildFluxQuery(range, config.compareRange, config.compareStop)
+      : null;
 
-    let previous: ClimateDataPoint[] | null = null;
-    if (compare && config.compareRange && config.compareStop) {
-      const previousQuery = buildFluxQuery(range, config.compareRange, config.compareStop);
-      const previousCSV = await queryInfluxDB(env, previousQuery);
-      previous = parseFluxCSV(previousCSV);
-    }
+    const [currentCSV, previousCSV] = await Promise.all([
+      queryInfluxDB(env, currentQuery),
+      previousQuery ? queryInfluxDB(env, previousQuery) : Promise.resolve(null),
+    ]);
+
+    const current = parseFluxCSV(currentCSV);
+    const previous = previousCSV ? parseFluxCSV(previousCSV) : null;
 
     const body = JSON.stringify({ current, previous });
     const response = new Response(body, {


### PR DESCRIPTION
## Summary
- Add `compareRange: "-60d"` and `compareStop: "-30d"` to the 30d worker config so the API supports comparison
- Remove all `range !== "30d"` guards in the frontend — the compare checkbox is now always visible

## Test plan
- [ ] Verify "Compare to previous period" checkbox appears on 30-day range
- [ ] Verify toggling it shows the dashed comparison line on 30d charts
- [ ] Verify existing 1h/24h/7d comparison still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)