### PR TITLE
Normalize API cache keys to prevent cache-busting

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -187,15 +187,18 @@ async function handleClimate(
   env: Env,
   ctx: ExecutionContext,
 ): Promise<Response> {
-  const cache = caches.default;
-  const cacheKey = new Request(new URL(request.url).toString());
-
-  const cached = await cache.match(cacheKey);
-  if (cached) return cached;
-
   const url = new URL(request.url);
   const range = url.searchParams.get("range") || "24h";
   const compare = url.searchParams.get("compare") === "true";
+
+  const cache = caches.default;
+  const normalizedUrl = new URL(url.pathname, url.origin);
+  normalizedUrl.searchParams.set("range", range);
+  if (compare) normalizedUrl.searchParams.set("compare", "true");
+  const cacheKey = new Request(normalizedUrl.toString());
+
+  const cached = await cache.match(cacheKey);
+  if (cached) return cached;
 
   const config = RANGE_CONFIG[range];
   if (!config) {
@@ -244,8 +247,9 @@ async function handleForecast(
   env: Env,
   ctx: ExecutionContext,
 ): Promise<Response> {
+  const url = new URL(request.url);
   const cache = caches.default;
-  const cacheKey = new Request(new URL(request.url).toString());
+  const cacheKey = new Request(new URL(url.pathname, url.origin).toString());
 
   const cached = await cache.match(cacheKey);
   if (cached) return cached;
@@ -283,8 +287,9 @@ async function handleLastfm(
   env: Env,
   ctx: ExecutionContext,
 ): Promise<Response> {
+  const url = new URL(request.url);
   const cache = caches.default;
-  const cacheKey = new Request(new URL(request.url).toString());
+  const cacheKey = new Request(new URL(url.pathname, url.origin).toString());
 
   const cached = await cache.match(cacheKey);
   if (cached) return cached;


### PR DESCRIPTION
## Summary
- Normalize cache keys across all three API handlers (climate, forecast, lastfm) to strip unknown query parameters
- Climate: cache key only includes `range` and `compare` params
- Forecast/LastFM: cache key uses pathname only, no query params
- Prevents attackers from bypassing the cache by appending arbitrary query params (e.g. `?_=123`), which would otherwise create unique cache entries and hit upstream APIs directly

## Test plan
- [ ] Verify `/api/climate?range=24h` and `/api/climate?range=24h&junk=1` return the same cached response
- [ ] Verify `/api/forecast` and `/api/forecast?_=123` return the same cached response
- [ ] Verify `/api/lastfm` and `/api/lastfm?foo=bar` return the same cached response
- [ ] Verify legitimate params (`range`, `compare`) still produce distinct cache entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)