### PR TITLE
Add swipeable photo carousel to Pixelfed cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@tailwindcss/typography": "^0.5.19",
         "astro": "^6.2.0",
         "astro-icon": "^1.1.0",
+        "embla-carousel-react": "^8.6.0",
         "fast-xml-parser": "^5.7.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -3852,6 +3853,34 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.351.tgz",
       "integrity": "sha512-9D7Iqx8RImSvCnOsj86rCH6eQjZFQoM04Jn6HnZVM0Nu/G58/gmKYQ1d12MZTbjQbQSTGI8nwEy07ErsA2slLA==",
       "license": "ISC"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
+      "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.6.0",
+        "embla-carousel-reactive-utils": "8.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+      "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@tailwindcss/typography": "^0.5.19",
     "astro": "^6.2.0",
     "astro-icon": "^1.1.0",
+    "embla-carousel-react": "^8.6.0",
     "fast-xml-parser": "^5.7.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/components/PhotoCard.tsx
+++ b/src/components/PhotoCard.tsx
@@ -1,5 +1,5 @@
 import useEmblaCarousel from "embla-carousel-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 interface Props {
   images: string[];
@@ -11,7 +11,6 @@ interface Props {
 export default function PhotoCard({ images, title, date, link }: Props) {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const hasMultiple = images.length > 1;
-  const clicked = useRef(false);
 
   const [emblaRef, emblaApi] = useEmblaCarousel({
     active: hasMultiple,
@@ -27,36 +26,20 @@ export default function PhotoCard({ images, title, date, link }: Props) {
     };
   }, [emblaApi]);
 
-  const handlePointerDown = useCallback(() => {
-    clicked.current = true;
-  }, []);
-
-  const handlePointerMove = useCallback(() => {
-    clicked.current = false;
-  }, []);
-
-  const handleClick = useCallback(
-    (e: React.MouseEvent) => {
-      if (!clicked.current && hasMultiple) {
-        e.preventDefault();
-      }
-      clicked.current = false;
-    },
-    [hasMultiple],
-  );
+  const handleCarouselClick = useCallback(() => {
+    if (!hasMultiple || !emblaApi || emblaApi.clickAllowed()) {
+      window.open(link, "_blank", "noreferrer");
+    }
+  }, [hasMultiple, emblaApi, link]);
 
   return (
-    <a
-      href={link}
-      target="_blank"
-      rel="noreferrer"
-      className="group block"
-      onClick={handleClick}
-      onPointerDown={handlePointerDown}
-      onPointerMove={handlePointerMove}
-    >
-      <div className="relative aspect-square overflow-hidden rounded-xl bg-gray-100">
-        <div ref={emblaRef} className="h-full">
+    <div className="group block">
+      <div
+        className="relative aspect-square overflow-hidden rounded-xl bg-gray-100 cursor-pointer"
+        onDragStart={(e) => e.preventDefault()}
+        onClick={handleCarouselClick}
+      >
+        <div ref={emblaRef} className="h-full overflow-hidden">
           <div className="flex h-full">
             {images.map((src, i) => (
               <div key={src} className="min-w-0 shrink-0 basis-full h-full">
@@ -64,9 +47,8 @@ export default function PhotoCard({ images, title, date, link }: Props) {
                   src={src}
                   alt={title || "Photo"}
                   loading={i === 0 ? "eager" : "lazy"}
-                  className="w-full h-full object-cover pointer-events-none select-none"
+                  className="w-full h-full object-cover select-none"
                   draggable={false}
-                  style={{ WebkitUserDrag: "none", WebkitTouchCallout: "none" } as React.CSSProperties}
                 />
               </div>
             ))}
@@ -88,14 +70,14 @@ export default function PhotoCard({ images, title, date, link }: Props) {
           </div>
         )}
       </div>
-      <div className="mt-3">
+      <a href={link} target="_blank" rel="noreferrer" className="block mt-3">
         {title && (
           <p className="text-gray-700 text-sm leading-snug line-clamp-2">
             {title}
           </p>
         )}
         <p className="text-gray-400 text-sm mt-1">{date}</p>
-      </div>
-    </a>
+      </a>
+    </div>
   );
 }

--- a/src/components/PhotoCard.tsx
+++ b/src/components/PhotoCard.tsx
@@ -1,0 +1,113 @@
+import { useState, useRef, useCallback } from "react";
+
+interface Props {
+  images: string[];
+  title: string;
+  date: string;
+  link: string;
+}
+
+export default function PhotoCard({ images, title, date, link }: Props) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const touchStartX = useRef(0);
+  const touchDeltaX = useRef(0);
+  const swiped = useRef(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const hasMultiple = images.length > 1;
+
+  const goTo = useCallback(
+    (index: number) => {
+      setCurrentIndex(Math.max(0, Math.min(index, images.length - 1)));
+    },
+    [images.length],
+  );
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    if (!hasMultiple) return;
+    touchStartX.current = e.touches[0].clientX;
+    touchDeltaX.current = 0;
+    swiped.current = false;
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (!hasMultiple) return;
+    touchDeltaX.current = e.touches[0].clientX - touchStartX.current;
+  };
+
+  const handleTouchEnd = () => {
+    if (!hasMultiple) return;
+    const threshold = 50;
+    if (Math.abs(touchDeltaX.current) > threshold) {
+      swiped.current = true;
+      if (touchDeltaX.current < 0) {
+        goTo(currentIndex + 1);
+      } else {
+        goTo(currentIndex - 1);
+      }
+    }
+  };
+
+  const handleClick = (e: React.MouseEvent) => {
+    if (swiped.current) {
+      e.preventDefault();
+      swiped.current = false;
+    }
+  };
+
+  return (
+    <a
+      href={link}
+      target="_blank"
+      rel="noreferrer"
+      className="group block"
+      onClick={handleClick}
+    >
+      <div
+        ref={containerRef}
+        className="relative aspect-square overflow-hidden rounded-xl bg-gray-100"
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+      >
+        <div
+          className="flex h-full transition-transform duration-300 ease-out"
+          style={{ transform: `translateX(-${currentIndex * 100}%)` }}
+        >
+          {images.map((src, i) => (
+            <img
+              key={src}
+              src={src}
+              alt={title || "Photo"}
+              loading={i === 0 ? "eager" : "lazy"}
+              className="w-full h-full object-cover shrink-0"
+            />
+          ))}
+        </div>
+
+        {hasMultiple && (
+          <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex gap-1.5 drop-shadow-md">
+            {images.map((_, i) => (
+              <span
+                key={i}
+                className={`block w-2 h-2 rounded-full transition-all duration-200 ${
+                  i === currentIndex
+                    ? "bg-white scale-100"
+                    : "bg-white/50 scale-[0.85]"
+                }`}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+      <div className="mt-3">
+        {title && (
+          <p className="text-gray-700 text-sm leading-snug line-clamp-2">
+            {title}
+          </p>
+        )}
+        <p className="text-gray-400 text-sm mt-1">{date}</p>
+      </div>
+    </a>
+  );
+}

--- a/src/components/PhotoCard.tsx
+++ b/src/components/PhotoCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from "react";
+import { useCallback, useRef, useState } from "react";
 
 interface Props {
   images: string[];
@@ -9,10 +9,10 @@ interface Props {
 
 export default function PhotoCard({ images, title, date, link }: Props) {
   const [currentIndex, setCurrentIndex] = useState(0);
-  const touchStartX = useRef(0);
-  const touchDeltaX = useRef(0);
+  const startX = useRef(0);
+  const deltaX = useRef(0);
+  const dragging = useRef(false);
   const swiped = useRef(false);
-  const containerRef = useRef<HTMLDivElement>(null);
 
   const hasMultiple = images.length > 1;
 
@@ -23,29 +23,54 @@ export default function PhotoCard({ images, title, date, link }: Props) {
     [images.length],
   );
 
+  const commitSwipe = () => {
+    const threshold = 50;
+    if (Math.abs(deltaX.current) > threshold) {
+      swiped.current = true;
+      goTo(currentIndex + (deltaX.current < 0 ? 1 : -1));
+    }
+  };
+
   const handleTouchStart = (e: React.TouchEvent) => {
     if (!hasMultiple) return;
-    touchStartX.current = e.touches[0].clientX;
-    touchDeltaX.current = 0;
+    startX.current = e.touches[0].clientX;
+    deltaX.current = 0;
     swiped.current = false;
   };
 
   const handleTouchMove = (e: React.TouchEvent) => {
     if (!hasMultiple) return;
-    touchDeltaX.current = e.touches[0].clientX - touchStartX.current;
+    deltaX.current = e.touches[0].clientX - startX.current;
   };
 
   const handleTouchEnd = () => {
     if (!hasMultiple) return;
-    const threshold = 50;
-    if (Math.abs(touchDeltaX.current) > threshold) {
-      swiped.current = true;
-      if (touchDeltaX.current < 0) {
-        goTo(currentIndex + 1);
-      } else {
-        goTo(currentIndex - 1);
-      }
-    }
+    commitSwipe();
+  };
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    if (!hasMultiple) return;
+    dragging.current = true;
+    startX.current = e.clientX;
+    deltaX.current = 0;
+    swiped.current = false;
+  };
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (!dragging.current) return;
+    deltaX.current = e.clientX - startX.current;
+  };
+
+  const handleMouseUp = () => {
+    if (!dragging.current) return;
+    dragging.current = false;
+    commitSwipe();
+  };
+
+  const handleMouseLeave = () => {
+    if (!dragging.current) return;
+    dragging.current = false;
+    commitSwipe();
   };
 
   const handleClick = (e: React.MouseEvent) => {
@@ -64,11 +89,14 @@ export default function PhotoCard({ images, title, date, link }: Props) {
       onClick={handleClick}
     >
       <div
-        ref={containerRef}
-        className="relative aspect-square overflow-hidden rounded-xl bg-gray-100"
+        className="relative aspect-square overflow-hidden rounded-xl bg-gray-100 select-none"
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}
         onTouchEnd={handleTouchEnd}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseLeave}
       >
         <div
           className="flex h-full transition-transform duration-300 ease-out"

--- a/src/components/PhotoCard.tsx
+++ b/src/components/PhotoCard.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useRef, useState } from "react";
+import useEmblaCarousel from "embla-carousel-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 interface Props {
   images: string[];
@@ -8,77 +9,41 @@ interface Props {
 }
 
 export default function PhotoCard({ images, title, date, link }: Props) {
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const startX = useRef(0);
-  const deltaX = useRef(0);
-  const dragging = useRef(false);
-  const swiped = useRef(false);
-
+  const [selectedIndex, setSelectedIndex] = useState(0);
   const hasMultiple = images.length > 1;
+  const clicked = useRef(false);
 
-  const goTo = useCallback(
-    (index: number) => {
-      setCurrentIndex(Math.max(0, Math.min(index, images.length - 1)));
+  const [emblaRef, emblaApi] = useEmblaCarousel({
+    active: hasMultiple,
+    watchDrag: hasMultiple,
+  });
+
+  useEffect(() => {
+    if (!emblaApi) return;
+    const onSelect = () => setSelectedIndex(emblaApi.selectedScrollSnap());
+    emblaApi.on("select", onSelect);
+    return () => {
+      emblaApi.off("select", onSelect);
+    };
+  }, [emblaApi]);
+
+  const handlePointerDown = useCallback(() => {
+    clicked.current = true;
+  }, []);
+
+  const handlePointerMove = useCallback(() => {
+    clicked.current = false;
+  }, []);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (!clicked.current && hasMultiple) {
+        e.preventDefault();
+      }
+      clicked.current = false;
     },
-    [images.length],
+    [hasMultiple],
   );
-
-  const commitSwipe = () => {
-    const threshold = 50;
-    if (Math.abs(deltaX.current) > threshold) {
-      swiped.current = true;
-      goTo(currentIndex + (deltaX.current < 0 ? 1 : -1));
-    }
-  };
-
-  const handleTouchStart = (e: React.TouchEvent) => {
-    if (!hasMultiple) return;
-    startX.current = e.touches[0].clientX;
-    deltaX.current = 0;
-    swiped.current = false;
-  };
-
-  const handleTouchMove = (e: React.TouchEvent) => {
-    if (!hasMultiple) return;
-    deltaX.current = e.touches[0].clientX - startX.current;
-  };
-
-  const handleTouchEnd = () => {
-    if (!hasMultiple) return;
-    commitSwipe();
-  };
-
-  const handleMouseDown = (e: React.MouseEvent) => {
-    if (!hasMultiple) return;
-    dragging.current = true;
-    startX.current = e.clientX;
-    deltaX.current = 0;
-    swiped.current = false;
-  };
-
-  const handleMouseMove = (e: React.MouseEvent) => {
-    if (!dragging.current) return;
-    deltaX.current = e.clientX - startX.current;
-  };
-
-  const handleMouseUp = () => {
-    if (!dragging.current) return;
-    dragging.current = false;
-    commitSwipe();
-  };
-
-  const handleMouseLeave = () => {
-    if (!dragging.current) return;
-    dragging.current = false;
-    commitSwipe();
-  };
-
-  const handleClick = (e: React.MouseEvent) => {
-    if (swiped.current) {
-      e.preventDefault();
-      swiped.current = false;
-    }
-  };
 
   return (
     <a
@@ -87,30 +52,25 @@ export default function PhotoCard({ images, title, date, link }: Props) {
       rel="noreferrer"
       className="group block"
       onClick={handleClick}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
     >
-      <div
-        className="relative aspect-square overflow-hidden rounded-xl bg-gray-100 select-none"
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={handleTouchEnd}
-        onMouseDown={handleMouseDown}
-        onMouseMove={handleMouseMove}
-        onMouseUp={handleMouseUp}
-        onMouseLeave={handleMouseLeave}
-      >
-        <div
-          className="flex h-full transition-transform duration-300 ease-out"
-          style={{ transform: `translateX(-${currentIndex * 100}%)` }}
-        >
-          {images.map((src, i) => (
-            <img
-              key={src}
-              src={src}
-              alt={title || "Photo"}
-              loading={i === 0 ? "eager" : "lazy"}
-              className="w-full h-full object-cover shrink-0"
-            />
-          ))}
+      <div className="relative aspect-square overflow-hidden rounded-xl bg-gray-100">
+        <div ref={emblaRef} className="h-full">
+          <div className="flex h-full">
+            {images.map((src, i) => (
+              <div key={src} className="min-w-0 shrink-0 basis-full h-full">
+                <img
+                  src={src}
+                  alt={title || "Photo"}
+                  loading={i === 0 ? "eager" : "lazy"}
+                  className="w-full h-full object-cover pointer-events-none select-none"
+                  draggable={false}
+                  style={{ WebkitUserDrag: "none", WebkitTouchCallout: "none" } as React.CSSProperties}
+                />
+              </div>
+            ))}
+          </div>
         </div>
 
         {hasMultiple && (
@@ -119,7 +79,7 @@ export default function PhotoCard({ images, title, date, link }: Props) {
               <span
                 key={i}
                 className={`block w-2 h-2 rounded-full transition-all duration-200 ${
-                  i === currentIndex
+                  i === selectedIndex
                     ? "bg-white scale-100"
                     : "bg-white/50 scale-[0.85]"
                 }`}

--- a/src/components/PhotoCard.tsx
+++ b/src/components/PhotoCard.tsx
@@ -1,5 +1,5 @@
 import useEmblaCarousel from "embla-carousel-react";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 interface Props {
   images: string[];
@@ -26,23 +26,20 @@ export default function PhotoCard({ images, title, date, link }: Props) {
     };
   }, [emblaApi]);
 
-  const handleCarouselClick = useCallback(() => {
-    if (!hasMultiple || !emblaApi || emblaApi.clickAllowed()) {
-      window.open(link, "_blank", "noreferrer");
-    }
-  }, [hasMultiple, emblaApi, link]);
-
   return (
     <div className="group block">
-      <div
-        className="relative aspect-square overflow-hidden rounded-xl bg-gray-100 cursor-pointer"
-        onDragStart={(e) => e.preventDefault()}
-        onClick={handleCarouselClick}
-      >
+      <div className="relative aspect-square overflow-hidden rounded-xl bg-gray-100">
         <div ref={emblaRef} className="h-full overflow-hidden">
           <div className="flex h-full">
             {images.map((src, i) => (
-              <div key={src} className="min-w-0 shrink-0 basis-full h-full">
+              <a
+                key={src}
+                href={link}
+                target="_blank"
+                rel="noreferrer"
+                className="min-w-0 shrink-0 basis-full h-full"
+                draggable={false}
+              >
                 <img
                   src={src}
                   alt={title || "Photo"}
@@ -50,7 +47,7 @@ export default function PhotoCard({ images, title, date, link }: Props) {
                   className="w-full h-full object-cover select-none"
                   draggable={false}
                 />
-              </div>
+              </a>
             ))}
           </div>
         </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,6 +7,7 @@ import { getRecentPosts } from "../data/pixelfed";
 import { getCurrentlyReading } from "../data/bookwyrm";
 import { getRecentTracks } from "../data/lastfm";
 import RecentListens from "../components/RecentListens";
+import PhotoCard from "../components/PhotoCard";
 import meImage from "../images/me.jpeg";
 import mapImage from "../images/map.png";
 
@@ -31,35 +32,13 @@ const recentTracks = await getRecentTracks(10);
       <h2 class="font-display text-emerald-500 opacity-80 text-4xl mb-8 font-bold">Recent photos</h2>
       <div class="grid grid-cols-2 md:grid-cols-4 gap-4 md:gap-5">
         {recentPhotos.map((post) => (
-          <a
-            href={post.link}
-            target="_blank"
-            rel="noreferrer"
-            class="group block"
-          >
-            <div class="relative aspect-square overflow-hidden rounded-xl bg-gray-100">
-              <Image
-                src={post.images[0]}
-                alt={post.title || "Photo"}
-                width={600}
-                height={600}
-                class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
-              />
-              {post.images.length > 1 && (
-                <div class="absolute top-3 right-3 bg-black/60 text-white text-sm font-medium px-2.5 py-1 rounded-lg backdrop-blur-sm">
-                  +{post.images.length - 1} more
-                </div>
-              )}
-            </div>
-            <div class="mt-3">
-              {post.title && (
-                <p class="text-gray-700 text-sm leading-snug line-clamp-2">{post.title}</p>
-              )}
-              <p class="text-gray-400 text-sm mt-1">
-                {post.date.toLocaleDateString("en-GB", { day: "numeric", month: "long", year: "numeric" })}
-              </p>
-            </div>
-          </a>
+          <PhotoCard
+            client:visible
+            images={post.images}
+            title={post.title}
+            date={post.date.toLocaleDateString("en-GB", { day: "numeric", month: "long", year: "numeric" })}
+            link={post.link}
+          />
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add swipeable image carousel to Pixelfed photo cards using [Embla Carousel](https://www.embla-carousel.com/)
- Slides are `<a>` tags linking to the Pixelfed post — Embla v8 automatically prevents navigation during drag gestures
- Circular paging dot indicators at bottom center for multi-image posts
- Single-image posts render without carousel or dots

## Test plan
- [ ] Verify drag/swipe works on desktop (mouse) and mobile (touch)
- [ ] Verify clicking a photo navigates to the Pixelfed post
- [ ] Verify dragging does NOT navigate (Embla auto-prevention)
- [ ] Verify dot indicators update when swiping between images
- [ ] Verify single-image cards have no dots and still link correctly
- [ ] Check desktop and mobile layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VN6jUM1wiG5qr9WfgXqrCs