### PR TITLE
Add signpost blog post for 'Not That Kind of PR'

### DIFF
--- a/src/content/blog/not-that-kind-of-pr.md
+++ b/src/content/blog/not-that-kind-of-pr.md
@@ -1,0 +1,10 @@
+---
+title: "Not That Kind of PR"
+description: "I wrote about pull request best practices over on the Sykes Technology blog — covering code reviews as learning opportunities, clear communication, and staying productive with stacked PRs."
+date: 2025-05-09
+tags: ["code-review", "engineering-culture"]
+---
+
+I wrote a post on the [Sykes Technology blog](https://sykes.technology/blog/2025/05/09/not-that-kind-of-pr) exploring pull request best practices — how code reviews work as both quality safeguards and learning opportunities, common pitfalls in writing and reviewing PRs, and techniques like stacked PRs for staying productive while waiting on reviews.
+
+[Read the full post on sykes.technology &rarr;](https://sykes.technology/blog/2025/05/09/not-that-kind-of-pr)


### PR DESCRIPTION
## Summary
- Adds a short signpost blog post linking to the full "Not That Kind of PR" article on sykes.technology
- Covers pull request best practices, code reviews as learning opportunities, and stacked PRs
- First entry in the blog content collection

## Test plan
- [ ] Verify `/blog/` index page shows the new post
- [ ] Verify `/blog/not-that-kind-of-pr/` renders correctly
- [ ] Verify the external link to sykes.technology works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnLWtAEMjsQhxMeHcKRvtX