### PR TITLE
Prevent browser heuristic caching of API responses

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -230,7 +230,7 @@ async function handleClimate(
     const response = new Response(body, {
       headers: {
         "Content-Type": "application/json",
-        "Cache-Control": `public, s-maxage=${config.cacheTTL}`,
+        "Cache-Control": `public, max-age=0, s-maxage=${config.cacheTTL}`,
       },
     });
 
@@ -270,7 +270,7 @@ async function handleForecast(
     const response = new Response(body, {
       headers: {
         "Content-Type": "application/json",
-        "Cache-Control": "public, s-maxage=3600",
+        "Cache-Control": "public, max-age=0, s-maxage=3600",
       },
     });
 
@@ -334,7 +334,7 @@ async function handleLastfm(
     const response = new Response(JSON.stringify({ tracks }), {
       headers: {
         "Content-Type": "application/json",
-        "Cache-Control": `public, s-maxage=${CACHE_TTL_SECONDS}`,
+        "Cache-Control": `public, max-age=0, s-maxage=${CACHE_TTL_SECONDS}`,
       },
     });
 


### PR DESCRIPTION
## Summary
- Add `max-age=0` to `Cache-Control` headers on all three API endpoints (climate, forecast, lastfm)
- Previously responses only set `s-maxage` which is ignored by browsers, causing them to fall back to heuristic freshness and potentially serve stale data from their own HTTP cache

## Test plan
- [ ] Verify API responses include `max-age=0` in `Cache-Control` header
- [ ] Confirm browser DevTools shows revalidation on each fetch rather than `(disk cache)`
- [ ] Confirm Cloudflare edge cache still serves within `s-maxage` window (no upstream InfluxDB/Last.fm hit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lxu8i9pGc7KBT9t8Z6nPa1